### PR TITLE
Upgrade the project to gradle 2.2

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath group: 'com.android.tools.build', name: 'gradle', version: '0.12.0+'
+    classpath group: 'com.android.tools.build', name: 'gradle', version: '1.1.0'
   }
 }
 
@@ -18,11 +18,11 @@ dependencies {
 
 android {
   compileSdkVersion 19
-  buildToolsVersion "19.1"
+  buildToolsVersion "21.1.2"
 
   defaultConfig {
     minSdkVersion 10
-    targetSdkVersion 19
+    targetSdkVersion 22
   }
 
   compileOptions {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
Summary:

The latest Android Plugin is not compatible with the gradle 1.1 we use in the project. This diff upgrades the project to the latest gradle and android build tool.

Test Plan:

1) import the project in intellij, see it opens successfully.