### PR TITLE
Add config for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: android
+
+android:
+  components:
+    - build-tools-21.1.2
+    - android-19
+  licenses:
+    - android-sdk-license-5be876d5
+
+before_script:
+    - ./gradlew assemble
+
+script:
+    - ./gradlew check
+
+jdk:
+  - oraclejdk7


### PR DESCRIPTION
Summary:

This diff adds the travis ci config, so that we can enable continuous integration.

Test Plan:

1) I tested this remotely at https://travis-ci.org/kangzhang/ig-json-parser/builds/61893009