### PR TITLE
Add JsonHelper interface

### DIFF
--- a/common/src/main/java/com/instagram/common/json/JsonHelper.java
+++ b/common/src/main/java/com/instagram/common/json/JsonHelper.java
@@ -1,0 +1,8 @@
+package com.instagram.common.json;
+
+/**
+ * The interface for generated JSON helper class. It can be used to do type checking on generated
+ * helper classes.
+ */
+public interface JsonHelper<ModelClassType> {
+}

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import com.instagram.common.json.JsonAnnotationProcessorConstants;
 import com.instagram.common.json.JsonFactoryHolder;
+import com.instagram.common.json.JsonHelper;
 import com.instagram.common.json.annotation.JsonField;
 import com.instagram.common.json.annotation.JsonType;
 import com.instagram.common.json.annotation.util.Console;
@@ -87,7 +88,8 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
           JsonGenerator.class,
           JsonParser.class,
           JsonToken.class,
-          JsonFactoryHolder.class);
+          JsonFactoryHolder.class,
+          JsonHelper.class);
 
       // Generate the set of imports from the parsable objects referenced.
       Set<String> typeImports = new HashSet<String>();
@@ -112,7 +114,12 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
       writer.emitImports(typeImports);
       writer.emitEmptyLine();
 
-      writer.beginType(mInjectedClassName, "class", EnumSet.of(PUBLIC, FINAL));
+      writer.beginType(
+          mInjectedClassName,
+          "class",
+          EnumSet.of(PUBLIC, FINAL),
+          null,
+          "JsonHelper<" + mSimpleClassName + ">");
       writer.emitEmptyLine();
 
       String returnValue = mAnnotation.postprocessingEnabled() ?

--- a/processor/src/test/java/com/instagram/common/json/annotation/processor/DeserializeTest.java
+++ b/processor/src/test/java/com/instagram/common/json/annotation/processor/DeserializeTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
+import com.instagram.common.json.JsonHelper;
 import com.instagram.common.json.annotation.processor.support.ExtensibleJSONWriter;
 import com.instagram.common.json.annotation.processor.uut.AlternateFieldUUT;
 import com.instagram.common.json.annotation.processor.uut.AlternateFieldUUT__JsonHelper;
@@ -145,6 +146,7 @@ public class DeserializeTest {
     jp.nextToken();
     SimpleParseUUT uut = SimpleParseUUT__JsonHelper.parseFromJson(jp);
 
+    assertTrue(new SimpleParseUUT__JsonHelper() instanceof JsonHelper);
     assertSame(intValue, uut.intField);
     assertSame(integerValue, uut.integerField.intValue());
     assertEquals(Float.valueOf(floatValue), Float.valueOf(uut.floatField));


### PR DESCRIPTION
Summary:

We run into this issue recently that we can't make a strong typed API to enforce type checking on the generated helper class.

In the following API:

  new AutoJsonParser\<Foo\>(Foo__JsonHelper.class)

We can't avoid people passing in Bar__JsonHelper.class instead of Foo__JsonHelper.class

Test Plan:

1) unittest