### PR TITLE
Switch the demo project to use android-apt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: android
 android:
   components:
     - build-tools-23.0.1
-    - android-19
+    - android-23
   licenses:
     - android-sdk-license-5be876d5
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -5,6 +5,7 @@ buildscript {
 
   dependencies {
     classpath group: 'com.android.tools.build', name: 'gradle', version: '1.1.0'
+    classpath group: 'com.neenbedankt.gradle.plugins', name: 'android-apt', version: '1.8'
   }
 }
 
@@ -17,12 +18,12 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
+  compileSdkVersion 23
   buildToolsVersion "23.0.1"
 
   defaultConfig {
     minSdkVersion 10
-    targetSdkVersion 22
+    targetSdkVersion 23
   }
 
   compileOptions {

--- a/demo/igmodel/AndroidManifest.xml
+++ b/demo/igmodel/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+        package="com.instagram.jsonbenchmark.igmodel">
+</manifest>
+

--- a/demo/igmodel/build.gradle
+++ b/demo/igmodel/build.gradle
@@ -1,38 +1,25 @@
-apply plugin: 'java'
+apply plugin: 'com.android.library'
+apply plugin: 'com.neenbedankt.android-apt'
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
-
-ext {
-  generatedSourcesDir = file("gen-src/main/java")
-}
-
-sourceSets {
-  main {
-    java {
-      srcDir 'src/main/java'
-    }
-  }
-  gensrc {
-    java {
-      srcDir 'gen-src/main/java'
-    }
-  }
-}
-
-compileJava {
-  doFirst {
-    // Directory should exists before compilation started.
-    generatedSourcesDir.mkdirs()
-  }
-  options.compilerArgs += [
-                       '-processor',
-                       'com.instagram.common.json.annotation.processor.JsonAnnotationProcessor',
-                       '-s',
-                       generatedSourcesDir
-  ]
-}
 dependencies {
+  apt project(':processor')
   compile project(':common')
-  compile project(':processor')
+}
+
+android {
+  compileSdkVersion 23
+  buildToolsVersion "23.0.1"
+  sourceCompatibility = 1.7
+  targetCompatibility = 1.7
+
+  sourceSets {
+    main {
+      manifest {
+        srcFile "AndroidManifest.xml"
+      }
+      java {
+        srcDir 'src/main/java'
+      }
+    }
+  }
 }

--- a/demo/src/main/java/com/instagram/common/json/app/BenchmarkActivity.java
+++ b/demo/src/main/java/com/instagram/common/json/app/BenchmarkActivity.java
@@ -22,8 +22,6 @@ import com.instagram.common.json.app.ommodel.OmListOfModels;
 import com.instagram.common.json.app.ommodel.OmModelRequest;
 import com.instagram.common.json.app.ommodel.OmModelWorker;
 
-import com.google.common.io.Closeables;
-
 public class BenchmarkActivity extends Activity {
   private String mJsonString;
 
@@ -116,7 +114,7 @@ public class BenchmarkActivity extends Activity {
     return sb.toString();
   }
 
-  String loadFromFile(int resourceId) throws IOException {
+  private String loadFromFile(int resourceId) throws IOException {
     InputStreamReader inputStreamReader = null;
 
     try {
@@ -136,7 +134,13 @@ public class BenchmarkActivity extends Activity {
 
       return sb.toString();
     } finally {
-      Closeables.closeQuietly(inputStreamReader);
+      try {
+        if (inputStreamReader != null) {
+          inputStreamReader.close();
+        }
+      } catch (IOException ignored) {
+        //ignored
+      }
     }
   }
 


### PR DESCRIPTION
Summary:

Right now the demo app declares the annotation processor as a direct dependency. This pulls guava and all other unnecessary dependencies to the demo app.

This diff switches the demo app to use https://bitbucket.org/hvisser/android-apt, which makes sure the annotation processors are not pulled in as dependencies.

We should have a runtime artifact in maven() later and update our readme file.

Test Plan:

1) ./gradlew :demo:installDebug
2) use the demo app and everything works.
