### PR TITLE
Change retention policy for JsonField from class to source

### DIFF
--- a/common/src/main/java/com/instagram/common/json/annotation/JsonField.java
+++ b/common/src/main/java/com/instagram/common/json/annotation/JsonField.java
@@ -6,13 +6,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 /**
  * Apply this to a field in a class annotated with {@link JsonType}.  This tells the annotation
  * processor which fields exist, and how they may to/from the json object.
  */
-@Retention(CLASS) @Target(FIELD)
+@Retention(SOURCE) @Target(FIELD)
 public @interface JsonField {
   /**
    * This controls how we deal with type mismatches.  If a {@link TypeMapping#EXACT} mapping is


### PR DESCRIPTION
Changes the retention from source to class. Source retention is being kept at jar compilation time, but android dx is not smart enough and keeps it in final apk, where we don't need one. This can impact apk size. 