### PR TITLE
Make processor output deterministic

### DIFF
--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonAnnotationProcessor.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonAnnotationProcessor.java
@@ -23,7 +23,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.annotation.Annotation;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -56,7 +56,7 @@ public class JsonAnnotationProcessor extends AbstractProcessor {
     private Map<TypeElement, JsonParserClassData> mClassElementToInjectorMap;
 
     State() {
-      mClassElementToInjectorMap = new HashMap<TypeElement, JsonParserClassData>();
+      mClassElementToInjectorMap = new LinkedHashMap<>();
     }
   }
   private State mState;


### PR DESCRIPTION
The processor was creating a HashMap of classes and then iterating over
it in order to generate output. This means that the order that output
classes were generated is non-deterministic (because Element.hashCode
is just Object.hashCode). This then determines the order that the files
end up in the jar.

Use a LinkedHashMap instead to get deterministic iteration order.