### PR TITLE
list jackson as dep of the annotation processor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group = "com.github.instagram"
-version = 0.7
+version = 0.8
 
 task wrapper(type: Wrapper) {
        gradleVersion = '4.1' //version required

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -9,6 +9,7 @@ repositories {
 
 dependencies {
   compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.1+'
+  compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.2.3+'
   compile project(':javawriter')
   compile project(':util')
   compile project(':common')


### PR DESCRIPTION
to fix the dependency issue caused by gradle 4.0 upgrade

tested with https://gist.github.com/kangzhang/ad2b99d5ea2e492370efc09707fa40f0