### PR TITLE
Add support for serializing/deserializing interfaces

### DIFF
--- a/common/src/main/java/com/instagram/common/json/JsonSerializationHandler.java
+++ b/common/src/main/java/com/instagram/common/json/JsonSerializationHandler.java
@@ -1,0 +1,11 @@
+package com.instagram.common.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+
+import java.io.IOException;
+
+public interface JsonSerializationHandler<T> {
+    void serializeToJson(JsonGenerator generator, T object) throws IOException;
+    T parseFromJson(JsonParser parser) throws IOException;
+}

--- a/common/src/main/java/com/instagram/common/json/annotation/JsonTypeName.java
+++ b/common/src/main/java/com/instagram/common/json/annotation/JsonTypeName.java
@@ -1,0 +1,9 @@
+package com.instagram.common.json.annotation;
+
+/**
+ * This annotation specifies a String getter that will return the runtime type of the object.
+ * This is used for interface types, which must serialize out a description of the JsonType
+ * that will be used to deserialize the object.
+ */
+public @interface JsonTypeName {
+}

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonAnnotationProcessor.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonAnnotationProcessor.java
@@ -126,7 +126,6 @@ public class JsonAnnotationProcessor extends AbstractProcessor {
         SourceGenerator injector = entry.getValue();
 
         try {
-          System.out.format("Writing source file: %s\n", injector.getInjectedFqcn());
           JavaFileObject jfo = mFiler.createSourceFile(injector.getInjectedFqcn(), typeElement);
           Writer writer = jfo.openWriter();
           writer.write(injector.getJavaCode(processingEnv.getMessager()));
@@ -237,7 +236,7 @@ public class JsonAnnotationProcessor extends AbstractProcessor {
                 mOmitSomeMethodBodies,
                 parentGeneratedClassName,
                 annotation);
-      } else if (kind == ElementKind.INTERFACE){
+      } else if (kind == ElementKind.INTERFACE) {
         injector = new JsonParserInterfaceData(
                 packageName,
                 typeElement.getQualifiedName().toString(),
@@ -281,7 +280,8 @@ public class JsonAnnotationProcessor extends AbstractProcessor {
         e.printStackTrace(new PrintWriter(stackTrace));
 
         error(element, "Unable to generate view injector for @JsonField.\n\n%s",
-                stackTrace.toString());      }
+                stackTrace.toString());
+      }
     }
   }
 

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
@@ -38,7 +38,8 @@ import static javax.lang.model.element.Modifier.*;
  * This collects the data about the fields of a class, and generates the java code to parse the
  * object.
  */
-public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
+public class JsonParserClassData extends ProcessorClassData<String, TypeData>
+        implements SourceGenerator {
 
   private final boolean mAbstractClass;
   private final boolean mGenerateSerializer;

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserInterfaceData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserInterfaceData.java
@@ -1,0 +1,265 @@
+package com.instagram.common.json.annotation.processor;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.instagram.common.json.JsonFactoryHolder;
+import com.instagram.common.json.JsonHelper;
+import com.instagram.common.json.annotation.JsonType;
+import com.instagram.common.json.annotation.util.Console;
+import com.instagram.common.json.annotation.util.ProcessorClassData;
+import com.instagram.javawriter.JavaWriter;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+
+import javax.annotation.Nullable;
+import javax.annotation.processing.Messager;
+
+import static javax.lang.model.element.Modifier.FINAL;
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.PUBLIC;
+import static javax.lang.model.element.Modifier.STATIC;
+
+
+/**
+ * This collects data about the configuration of an interface, and generates the java code to
+ * dispatch parsing of that interface to implementations of that interface.
+ */
+public class JsonParserInterfaceData implements SourceGenerator {
+    private final String mClassPackage;
+    private final String mQualifiedClassName;
+    private final String mSimpleClassName;
+    private final String mInjectedClassName;
+    private final ProcessorClassData.AnnotationRecordFactory<String, TypeData> mFactory;
+    private String mTypeNameGetter;
+    private final JsonType mAnnotation;
+
+    public JsonParserInterfaceData(
+            String classPackage,
+            String qualifiedClassName,
+            String simpleClassName,
+            String injectedClassName,
+            ProcessorClassData.AnnotationRecordFactory<String, TypeData> factory,
+            JsonType annotation) {
+        mClassPackage = classPackage;
+        mQualifiedClassName = qualifiedClassName;
+        mSimpleClassName = simpleClassName;
+        mInjectedClassName = injectedClassName;
+        mFactory = factory;
+        mAnnotation = annotation;
+    }
+
+    @Override
+    public String getInjectedFqcn() {
+        return mClassPackage + '.' + mInjectedClassName;
+    }
+
+    @Override
+    public String getJavaCode(Messager messager) {
+        StringWriter sw = new StringWriter();
+        JavaWriter writer = new JavaWriter(sw);
+
+        try {
+            writer.emitPackage(mClassPackage)
+
+                .emitImports(
+                    JsonFactoryHolder.class,
+                    JsonGenerator.class,
+                    JsonHelper.class,
+                    JsonParser.class,
+                    JsonToken.class,
+                    IOException.class,
+                    HashMap.class,
+                    Nullable.class)
+
+                .emitEmptyLine()
+
+                .beginType(
+                    mInjectedClassName,
+                    "class",
+                    EnumSet.of(PUBLIC, FINAL),
+                    null,
+                    "JsonHelper<" + mSimpleClassName + ">")
+
+                .emitField(
+                    "HashMap<String,SerializationHandler>",
+                    "sHandlerMap",
+                    EnumSet.of(PRIVATE, STATIC, FINAL),
+                    "new HashMap<>()")
+
+                .emitEmptyLine();
+
+            emitHandlerInterface(sw, writer);
+
+            writer.emitEmptyLine();
+
+            emitRegisterHandlerMethod(writer);
+
+            writer.emitEmptyLine();
+
+            emitUnregisterHandlerMethod(writer);
+
+            writer.emitEmptyLine();
+
+            emitGetHandlerMethod(writer);
+
+            writer.emitEmptyLine();
+
+            emitParseFromJsonFromJsonParser(writer);
+
+            writer.emitEmptyLine();
+
+            emitParseFromJsonFromString(writer);
+
+            writer.emitEmptyLine();
+
+            emitSerializeToJson(writer);
+
+            writer.endType();
+            writer.close();
+        } catch (IOException ex) {
+            Console.error(
+                    messager, "IOException while generating %s: %s",
+                    mInjectedClassName, ex.toString());
+        }
+        return sw.toString();
+    }
+
+    private void emitHandlerInterface(StringWriter sw, JavaWriter writer) throws IOException {
+        writer.beginType(
+                "SerializationHandler",
+                "interface",
+                EnumSet.of(PUBLIC));
+        // JavaWriter does not support emitting interface methods.
+        sw.write("    void serializeToJson(JsonGenerator generator, " + mSimpleClassName + " object) throws IOException;\n");
+        sw.write("    " + mSimpleClassName + " parseFromJson(JsonParser parser) throws IOException;\n");
+        writer.endType();
+    }
+
+    private static void emitRegisterHandlerMethod(JavaWriter writer) throws IOException {
+        writer.beginMethod(
+                "void",
+                "registerHandler",
+                EnumSet.of(PUBLIC, STATIC),
+                "String", "typeName",
+                "SerializationHandler", "handler")
+
+            .beginControlFlow("if (sHandlerMap.containsKey(typeName))")
+            .emitStatement("final String message = String.format(\n"
+                + "\"Duplicate handler type name. %%s is already mapped to an instance of %%s\",\n"
+                + "typeName,\nsHandlerMap.get(typeName).getClass().getName())")
+            .emitStatement("throw new IllegalArgumentException(message)")
+            .endControlFlow()
+
+            .emitStatement("sHandlerMap.put(typeName, handler)")
+
+            .endMethod();
+    }
+
+    private static void emitUnregisterHandlerMethod(JavaWriter writer) throws IOException {
+        writer.beginMethod(
+                "void",
+                "unregisterHandler",
+                EnumSet.of(PUBLIC, STATIC),
+                "String", "typeName")
+            .emitStatement("sHandlerMap.remove(typeName)")
+            .endMethod();
+    }
+
+    private static void emitGetHandlerMethod(JavaWriter writer) throws IOException {
+        writer
+            .beginMethod(
+                "SerializationHandler",
+                "getHandler",
+                EnumSet.of(PRIVATE, STATIC),
+                "String", "typeName")
+            .emitStatement("final @Nullable SerializationHandler handler = sHandlerMap.get(typeName)")
+
+            .beginControlFlow("if (handler == null)")
+            .emitStatement("final String message = String.format(\n"
+                + "\"No SerializationHandler registered for type name: %%s\",\n"
+                + "typeName)")
+            .emitStatement("throw new IllegalArgumentException(message)")
+            .endControlFlow()
+            .emitEmptyLine()
+            .emitStatement("return handler")
+
+            .endMethod();
+    }
+
+    private void emitParseFromJsonFromJsonParser(JavaWriter writer) throws IOException {
+        writer.beginMethod(
+                mSimpleClassName,
+                "parseFromJson",
+                EnumSet.of(PUBLIC, STATIC),
+                Arrays.asList("JsonParser", "parser"),
+                Collections.singletonList("IOException"))
+
+            .beginControlFlow("if (parser.getCurrentToken() != JsonToken.START_ARRAY)")
+            .emitStatement("parser.skipChildren()")
+            .endControlFlow()
+
+            .emitEmptyLine()
+            .emitStatement("parser.nextToken()")
+            .beginControlFlow("if (parser.getCurrentToken() != JsonToken.VALUE_STRING)")
+            .emitStatement("parser.skipChildren()")
+            .endControlFlow()
+
+            .emitEmptyLine()
+            .emitStatement("String typeName = parser.getText()")
+            .emitStatement("parser.nextToken()")
+            .emitStatement(
+              "final %s instance = getHandler(typeName).parseFromJson(parser)", mSimpleClassName)
+            .emitStatement("parser.nextToken()")
+            .emitStatement("return instance")
+
+            .endMethod();
+    }
+
+    private void emitParseFromJsonFromString(JavaWriter writer) throws IOException {
+        writer.beginMethod(
+                mSimpleClassName,
+                "parseFromJson",
+                EnumSet.of(PUBLIC, STATIC),
+                Arrays.asList("String", "inputString"),
+                Collections.singletonList("IOException"))
+
+            .emitStatement("JsonParser jp = JsonFactoryHolder.APP_FACTORY.createParser(inputString)")
+            .emitStatement("jp.nextToken()")
+            .emitStatement("return parseFromJson(jp)")
+
+            .endMethod();
+    }
+
+    private void emitSerializeToJson(JavaWriter writer) throws IOException {
+        writer
+            .emitSingleLineComment("writeStartAndEnd is included for API compatibility, but is ignored.")
+            .beginMethod(
+                "void",
+                "serializeToJson",
+                EnumSet.of(PUBLIC, STATIC),
+                Arrays.asList(
+                        "JsonGenerator", "generator",
+                        mSimpleClassName, "object",
+                        "boolean", "writeStartAndEndIgnored"),
+                Collections.singletonList("IOException"))
+            .emitStatement("generator.writeStartArray()")
+            .emitStatement("generator.writeString(object.%s())", mTypeNameGetter)
+            .emitStatement("getHandler(object.%s()).serializeToJson(generator, object)", mTypeNameGetter)
+            .emitStatement("generator.writeEndArray()")
+            .endMethod();
+    }
+
+    public String getTypeNameGetter() {
+        return mTypeNameGetter;
+    }
+
+    public void setTypeNameGetter(String typeNameGetter) {
+        mTypeNameGetter = typeNameGetter;
+    }
+}

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/SourceGenerator.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/SourceGenerator.java
@@ -1,0 +1,8 @@
+package com.instagram.common.json.annotation.processor;
+
+import javax.annotation.processing.Messager;
+
+public interface SourceGenerator {
+    String getInjectedFqcn();
+    String getJavaCode(Messager messager);
+}

--- a/processor/src/test/java/com/instagram/common/json/annotation/processor/SerializeTest.java
+++ b/processor/src/test/java/com/instagram/common/json/annotation/processor/SerializeTest.java
@@ -19,6 +19,10 @@ import com.instagram.common.json.annotation.processor.uut.MapUUT;
 import com.instagram.common.json.annotation.processor.uut.MapUUT__JsonHelper;
 import com.instagram.common.json.annotation.processor.uut.SimpleParseUUT;
 import com.instagram.common.json.annotation.processor.uut.SimpleParseUUT__JsonHelper;
+import com.instagram.common.json.annotation.processor.dependent.InterfaceImplementationUUT;
+import com.instagram.common.json.annotation.processor.dependent.InterfaceImplementationUUT__JsonHelper;
+import com.instagram.common.json.annotation.processor.parent.InterfaceParentUUT;
+import com.instagram.common.json.annotation.processor.parent.InterfaceParentUUT__JsonHelper;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -351,5 +355,35 @@ public class SerializeTest {
     GetterUUT parsed = GetterUUT__JsonHelper.parseFromJson(inputString);
 
     assertEquals(10, parsed.intField);
+  }
+
+  @Test
+  public void serializeInterfaceTest() throws IOException {
+    InterfaceParentUUT__JsonHelper.registerHandler(
+            InterfaceImplementationUUT.TYPE_NAME,
+            new InterfaceParentUUT__JsonHelper.SerializationHandler() {
+              public void serializeToJson(JsonGenerator generator, InterfaceParentUUT object)
+                      throws IOException {
+                InterfaceImplementationUUT__JsonHelper
+                        .serializeToJson(generator, (InterfaceImplementationUUT)object, true);
+              }
+              public InterfaceParentUUT parseFromJson(JsonParser parser) throws IOException {
+                return InterfaceImplementationUUT__JsonHelper.parseFromJson(parser);
+              }
+            });
+    StringWriter stringWriter = new StringWriter();
+    JsonGenerator jsonGenerator = new JsonFactory().createGenerator(stringWriter);
+
+    InterfaceImplementationUUT obj = new InterfaceImplementationUUT();
+    obj.stringField = "testValue";
+    InterfaceParentUUT__JsonHelper.serializeToJson(jsonGenerator, obj, true);
+
+    jsonGenerator.close();
+    String serialized = stringWriter.toString();
+    InterfaceParentUUT parsed = InterfaceParentUUT__JsonHelper.parseFromJson(serialized);
+    assertTrue(parsed instanceof InterfaceImplementationUUT);
+    InterfaceImplementationUUT parsedObj = (InterfaceImplementationUUT) parsed;
+    assertEquals(obj.stringField, parsedObj.stringField);
+
   }
 }

--- a/processor/src/test/java/com/instagram/common/json/annotation/processor/SerializeTest.java
+++ b/processor/src/test/java/com/instagram/common/json/annotation/processor/SerializeTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 
+import com.instagram.common.json.JsonSerializationHandler;
 import com.instagram.common.json.annotation.processor.uut.GetterUUT;
 import com.instagram.common.json.annotation.processor.uut.GetterUUT__JsonHelper;
 import com.instagram.common.json.annotation.processor.uut.EnumUUT;
@@ -361,7 +362,7 @@ public class SerializeTest {
   public void serializeInterfaceTest() throws IOException {
     InterfaceParentUUT__JsonHelper.registerHandler(
             InterfaceImplementationUUT.TYPE_NAME,
-            new InterfaceParentUUT__JsonHelper.SerializationHandler() {
+            new JsonSerializationHandler<InterfaceParentUUT>() {
               public void serializeToJson(JsonGenerator generator, InterfaceParentUUT object)
                       throws IOException {
                 InterfaceImplementationUUT__JsonHelper

--- a/processor/testuut/dependent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceImplementationUUT.java
+++ b/processor/testuut/dependent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceImplementationUUT.java
@@ -1,0 +1,20 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.instagram.common.json.annotation.processor.dependent;
+
+import com.instagram.common.json.annotation.JsonField;
+import com.instagram.common.json.annotation.JsonType;
+import com.instagram.common.json.annotation.processor.parent.InterfaceParentUUT;
+
+@JsonType()
+public class InterfaceImplementationUUT implements InterfaceParentUUT {
+    public static final String TYPE_NAME = "InterfaceImplementationUUT";
+
+    @JsonField(fieldName = "stringField")
+    public String stringField;
+
+    @Override
+    public String getTypeNameYeah() {
+        return TYPE_NAME;
+    }
+}

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentUUT.java
@@ -1,0 +1,13 @@
+package com.instagram.common.json.annotation.processor.parent;
+
+import com.instagram.common.json.annotation.JsonType;
+import com.instagram.common.json.annotation.JsonTypeName;
+
+/**
+ * Interface parent to test that polymorphic deserialization works.
+ */
+@JsonType
+public interface InterfaceParentUUT {
+    @JsonTypeName
+    String getTypeNameYeah();
+}


### PR DESCRIPTION
This PR adds support for serializing objects from an interface reference. Using this, you can serialize out e.g. a list of heterogenous object types.

## Using the Public API

Say you have a field that refers to an instance of `MyInterface`. 

```
@JsonType
public class MySerializableObject {
  @JsonField(fieldName = "my_interface")
  MyInterface mMyInterface;
}
```

First step is to add a method to the interface to return the type name:

```
@JsonType
public interface MyInterface {
  @JsonTypeName
  String getTypeName();
}
```

Then in your implementation of that interface, you yield the type name:

```
@JsonType
public class MyImplementation implements MyInterface {
  public static final String TYPE_NAME = "MyImplementation";
  @Override
  public String getTypeName() {
    return TYPE_NAME;
  }
}
```

Then before you serialize, you register a serialization handler with the generated code:

```
MyInterface__JsonHelper.registerHandler(
  MyImplementation.TYPE_NAME,
  new JsonSerializationHandler<MyInterface>() {
    @Override
    public void serializeToJson(JsonGenerator generator, MyInterface object)
                      throws IOException {
      MyImplementation__JsonHelper
          .serializeToJson(generator, (MyImplementation)object, true);
    }
    public MyInterface parseFromJson(JsonParser parser) throws IOException {
      return MyImplementation__JsonHelper.parseFromJson(parser);
    }
  });
```

With that, `MySerializableObject` can successfully serialize and deserialize:

```
String json = MySerializableObject__JsonHelper.serializeToJson(object);
MySerializableObject deserialized = MySerializableObject__JsonHelper.parseFromJson(json);
```

## Under the Hood

Not seen above is the JSON representation. For this to work, the type has to be represented in the serialized JSON. Not only that, but some ordering must be guaranteed if we want to go with the existing single-pass parse style. This is because we must read in the type first before we dispatch to that specific type's parser.

The only JSON aggregate that guarantees ordering is the list. So interfaces are represented as lists, where the first entry is the type information, and the second entry is the object data:

```
[
  "InterfaceImplementationUUT",
  {
    "stringField":"testValue"
  }
]
```