### PR TITLE
Add the ability for serializers/parsers to refer to interfaces

### DIFF
--- a/common/src/main/java/com/instagram/common/json/annotation/JsonType.java
+++ b/common/src/main/java/com/instagram/common/json/annotation/JsonType.java
@@ -56,6 +56,14 @@ public @interface JsonType {
   String valueExtractFormatter() default DEFAULT_VALUE_EXTRACT_FORMATTER;
 
   /**
+   * Use the specified serialization formatter to generate JSON for this object. Like
+   * {@link JsonType#valueExtractFormatter()}, this can be used to extend the serializer.
+   *
+   * @return
+   */
+  String serializeCodeFormatter() default "";
+
+  /**
    * If set to YES, or NO, will override the global option for generating serializer methods.
    * Preventing generation of serializer methods when you don't use them may help save on binary size of
    * the generated code.

--- a/common/src/main/java/com/instagram/common/json/annotation/JsonType.java
+++ b/common/src/main/java/com/instagram/common/json/annotation/JsonType.java
@@ -48,6 +48,10 @@ public @interface JsonType {
    * will change the visibility of the JsonHelper parse methods to <b>protected</b> to avoid
    * mistakes by client code which might call those methods directly by accident.
    *
+   * <p>Interfaces do not generate parse code, so compilation will fail if an interface appears
+   * in a {@link JsonField} without a valueExtractFormatter on either the {@link JsonField} or
+   * the {@link JsonType}.
+   *
    * <p>See {@link JsonField#valueExtractFormatter()} for a description of the available
    * substitutions.
    *
@@ -64,7 +68,11 @@ public @interface JsonType {
    * {@link JsonType#serializeCodeFormatter()} for an interface type, which will not generate its
    * own JsonHelper.
    *
-   * <p> See {@link JsonField#serializeCodeFormatter()} for more details.</p>
+   * <p>Interfaces do not generate serialization code, so compilation will fail if an interface
+   * is referenced in a serializer without either {@link JsonType}'s {@link JsonType#serializeCodeFormatter()}
+   * or {@link JsonField#serializeCodeFormatter()} provided.
+   *
+   * <p> See {@link JsonField#serializeCodeFormatter()} for more details.
    *
    * @return
    */

--- a/common/src/main/java/com/instagram/common/json/annotation/JsonType.java
+++ b/common/src/main/java/com/instagram/common/json/annotation/JsonType.java
@@ -39,7 +39,9 @@ public @interface JsonType {
   /**
    * Use the specified value extract formatter to parse this object whenever it is encountered by
    * the parser. This can be used as an 'escape hatch' to parse non-standard JSON or a way to add
-   * additional default behavior to the standard parser.
+   * additional default behavior to the standard parser. This can also be used to extract interface
+   * values: a {@link JsonType} annotation on an interface will not generate a JsonHelper, but
+   * it can be used to hook up a {@link JsonType#valueExtractFormatter()} for that type.
    *
    * <p>This does not change the generated JsonHelper code for this object; rather it changes
    * the JsonHelper code for all objects that refer to this object. However, using this parameter
@@ -57,7 +59,12 @@ public @interface JsonType {
 
   /**
    * Use the specified serialization formatter to generate JSON for this object. Like
-   * {@link JsonType#valueExtractFormatter()}, this can be used to extend the serializer.
+   * {@link JsonType#valueExtractFormatter()}, this can be used to extend the serializer. Also like
+   * {@link JsonType#valueExtractFormatter()}, this can be used to hook up a
+   * {@link JsonType#serializeCodeFormatter()} for an interface type, which will not generate its
+   * own JsonHelper.
+   *
+   * <p> See {@link JsonField#serializeCodeFormatter()} for more details.</p>
    *
    * @return
    */

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 26 16:35:09 PST 2018
+#Mon Nov 06 17:09:34 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Nov 06 17:09:34 EST 2017
+#Fri Jan 26 16:35:09 PST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonAnnotationProcessor.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonAnnotationProcessor.java
@@ -171,13 +171,6 @@ public class JsonAnnotationProcessor extends AbstractProcessor {
     // The annotation should be validated for an interface, but no code should be generated.
     JsonType annotation = element.getAnnotation(JsonType.class);
     if (element.getKind() == INTERFACE) {
-      if (StringUtil.isNullOrEmpty(annotation.serializeCodeFormatter())) {
-        error(
-                element,
-                "@%s requires a serializeCodeFormatter when applied to interfaces. (%s.%s)",
-                JsonType.class.getSimpleName(),
-                element.getSimpleName());
-      }
       if (annotation.valueExtractFormatter().equals(DEFAULT_VALUE_EXTRACT_FORMATTER)) {
         error(
                 element,
@@ -318,15 +311,18 @@ public class JsonAnnotationProcessor extends AbstractProcessor {
       data.setParsableTypeParserClass(
           mTypeUtils.getPrefixForGeneratedClass(typeElement, packageName));
 
+      JsonType typeAnnotation = typeElement.getAnnotation(JsonType.class);
       if (StringUtil.isNullOrEmpty(data.getValueExtractFormatter())) {
         // Use the parsable object's value extract formatter
         data.setValueExtractFormatter(
-            typeElement.getAnnotation(JsonType.class).valueExtractFormatter());
+            typeAnnotation.valueExtractFormatter());
       }
       if (StringUtil.isNullOrEmpty(data.getSerializeCodeFormatter())) {
         data.setSerializeCodeFormatter(
-            typeElement.getAnnotation(JsonType.class).serializeCodeFormatter());
+            typeAnnotation.serializeCodeFormatter());
       }
+
+      data.setIsInterface(typeElement.getKind() == INTERFACE);
     } else if (data.getParseType() == TypeUtils.ParseType.ENUM_OBJECT) {
       // verify that we have value extract and serializer formatters.
       if (StringUtil.isNullOrEmpty(annotation.valueExtractFormatter()) ||

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonAnnotationProcessor.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonAnnotationProcessor.java
@@ -171,14 +171,6 @@ public class JsonAnnotationProcessor extends AbstractProcessor {
     // The annotation should be validated for an interface, but no code should be generated.
     JsonType annotation = element.getAnnotation(JsonType.class);
     if (element.getKind() == INTERFACE) {
-      if (annotation.valueExtractFormatter().equals(DEFAULT_VALUE_EXTRACT_FORMATTER)) {
-        error(
-                element,
-                "@%s requires a valueExtractF when applied to interfaces. (%s.%s)",
-                JsonType.class.getSimpleName(),
-                element.getSimpleName());
-      }
-
       return;
     }
 

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
@@ -589,6 +589,18 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
       } else {
         if (data.getParseType() == TypeUtils.ParseType.PARSABLE_OBJECT) {
           if (StringUtil.isNullOrEmpty(serializeCode)) {
+            if (data.isInterface()) {
+              Console.error(
+                      messager,
+                      "Interface %s cannot be serialized without a serializeCodeFormatter "
+                              + "on either the interface's %s or field's %s annotation. (%s.%s)",
+                      data.getParsableType(),
+                      JsonType.class.getSimpleName(),
+                      JsonField.class.getSimpleName(),
+                      mSimpleClassName,
+                      member);
+
+            }
             serializeCode = PARSABLE_OBJECT_SERIALIZE_CALL;
           }
           writer

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
@@ -275,6 +275,7 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
 
     boolean firstEntry = true;
     for (Map.Entry<String, TypeData> entry : getIterator()) {
+      String member = entry.getKey();
       TypeData data = entry.getValue();
 
       String condition = "\"" + data.getFieldName() + "\".equals(fieldName)";
@@ -290,7 +291,7 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
       }
 
       if (data.getCollectionType() != TypeUtils.CollectionType.NOT_A_COLLECTION) {
-        generateCollectionParser(messager, writer, data);
+        generateCollectionParser(messager, writer, data, member);
         String assignmentFormatter = data.getAssignmentFormatter();
         if (StringUtil.isNullOrEmpty(assignmentFormatter)) {
           assignmentFormatter = DEFAULT_ASSIGNMENT_FORMATTER;
@@ -298,11 +299,11 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
         writer.emitStatement(
             StrFormat.createStringFormatter(assignmentFormatter)
                 .addParam("object_varname", "instance")
-                .addParam("field_varname", entry.getKey())
+                .addParam("field_varname", member)
                 .addParam("extracted_value", "results")
                 .format());
       } else {
-        String rValue = generateExtractRvalue(data);
+        String rValue = generateExtractRvalue(data, messager, member);
         String assignmentFormatter = data.getAssignmentFormatter();
         if (StringUtil.isNullOrEmpty(assignmentFormatter)) {
           assignmentFormatter = DEFAULT_ASSIGNMENT_FORMATTER;
@@ -310,7 +311,7 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
         writer.emitStatement(
             StrFormat.createStringFormatter(assignmentFormatter)
                 .addParam("object_varname", "instance")
-                .addParam("field_varname", entry.getKey())
+                .addParam("field_varname", member)
                 .addParam("extracted_value", rValue)
                 .format());
       }
@@ -325,19 +326,19 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
     }
   }
 
-  private void generateCollectionParser(Messager messager, JavaWriter writer, TypeData data)
+  private void generateCollectionParser(Messager messager, JavaWriter writer, TypeData data, String member)
       throws IOException {
     if (TypeUtils.isMapType(data.getCollectionType())) {
-      generateMapParser(messager, writer, data);
+      generateMapParser(messager, writer, data, member);
     } else {
-      generateArrayParser(messager, writer, data);
+      generateArrayParser(messager, writer, data, member);
     }
   }
 
   /**
    * This writes the code to properly parse an array.
    */
-  private void generateArrayParser(Messager messager, JavaWriter writer, TypeData data)
+  private void generateArrayParser(Messager messager, JavaWriter writer, TypeData data, String member)
       throws IOException {
     String innerType = getJavaType(messager, data);
     String interfaceType = mapCollectionTypeToInterfaceType(data.getCollectionType());
@@ -347,7 +348,7 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
         .beginControlFlow("if (jp.getCurrentToken() == JsonToken.START_ARRAY)")
         .emitStatement("results = new %s<%s>()", concreteType, innerType)
         .beginControlFlow("while (jp.nextToken() != JsonToken.END_ARRAY)")
-        .emitStatement("%s parsed = %s", innerType, generateExtractRvalue(data))
+        .emitStatement("%s parsed = %s", innerType, generateExtractRvalue(data, messager, member))
         .beginControlFlow("if (parsed != null)")
         .emitStatement("results.add(parsed)")
         .endControlFlow()
@@ -355,7 +356,7 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
         .endControlFlow();
   }
 
-  private void generateMapParser(Messager messager, JavaWriter writer, TypeData valueTypeData)
+  private void generateMapParser(Messager messager, JavaWriter writer, TypeData valueTypeData, String member)
       throws IOException {
     TypeData keyTypeData = new TypeData();
     keyTypeData.setParseType(TypeUtils.ParseType.STRING);
@@ -378,7 +379,7 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
         .emitStatement(
             "%s parsedValue = %s",
             valueType,
-            generateExtractRvalue(valueTypeData))
+            generateExtractRvalue(valueTypeData, messager, member))
         .beginControlFlow("if (parsedValue != null)")
         .emitStatement("results.put(parsedKey, parsedValue)")
         .endControlFlow()
@@ -391,10 +392,21 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
    * We allow consumers of this library to override how we interact with the jackson to get the
    * value.  This generates the code to generate the rvalue expression.
    */
-  private String generateExtractRvalue(TypeData data) {
+  private String generateExtractRvalue(TypeData data, Messager messager, String member) {
     String valueExtractFormatter = data.getValueExtractFormatter();
 
     if (StringUtil.isNullOrEmpty(valueExtractFormatter)) {
+      if (data.isInterface()) {
+        Console.error(
+                messager,
+                "Interface %s cannot be parsed without a valueExtractFormatter "
+                        + "on either the interface's %s or field's %s annotation. (%s.%s)",
+                data.getParsableType(),
+                JsonType.class.getSimpleName(),
+                JsonField.class.getSimpleName(),
+                mSimpleClassName,
+                member);
+      }
       if (data.getMapping() == JsonField.TypeMapping.EXACT) {
         valueExtractFormatter = sExactFormatters.get(data.getParseType());
       } else if (data.getMapping() == JsonField.TypeMapping.COERCED) {
@@ -599,7 +611,6 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
                       JsonField.class.getSimpleName(),
                       mSimpleClassName,
                       member);
-
             }
             serializeCode = PARSABLE_OBJECT_SERIALIZE_CALL;
           }

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/TypeData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/TypeData.java
@@ -6,6 +6,8 @@ import com.instagram.common.json.annotation.JsonField;
 import com.instagram.common.json.annotation.JsonType;
 import com.instagram.common.json.annotation.util.TypeUtils;
 
+import javax.annotation.Nullable;
+
 /**
  * Represents the data needed to serialize and deserialize a field. These roughly correspond
  * to the attributes of the JsonField annotation.
@@ -158,6 +160,12 @@ class TypeData {
     mParsableType = parsableType;
   }
 
+  /**
+   * This is the name of the helper parser class, without the suffix applied. Some parsable types
+   * do not generate helper classes at all (interfaces), so this value can be null.
+   * @return
+   */
+  @Nullable
   String getParsableTypeParserClass() {
     return mParsableTypeParserClass;
   }

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/TypeData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/TypeData.java
@@ -79,6 +79,7 @@ class TypeData {
    * If this is a parsable object, the name of this field's parser class.
    */
   private String mParsableTypeParserClass;
+  private boolean mIsInterface;
 
   String getFieldName() {
     return mFieldName;
@@ -186,5 +187,17 @@ class TypeData {
     return getParseType() == TypeUtils.ParseType.PARSABLE_OBJECT &&
             !getPackageName().equals(packageName) &&
             !StringUtil.isNullOrEmpty(getParsableTypeParserClass());
+  }
+
+  public void setIsInterface(boolean isInterface) {
+    mIsInterface = isInterface;
+  }
+
+  public boolean isInterface() {
+    return mIsInterface;
+  }
+
+  public void setInterface(boolean isInterface) {
+    mIsInterface = isInterface;
   }
 }

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/TypeData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/TypeData.java
@@ -173,4 +173,10 @@ class TypeData {
   void setEnumType(String enumType) {
     mEnumType = enumType;
   }
+
+  public boolean needsImportFrom(String packageName) {
+    return getParseType() == TypeUtils.ParseType.PARSABLE_OBJECT &&
+            !getPackageName().equals(packageName) &&
+            !StringUtil.isNullOrEmpty(getParsableTypeParserClass());
+  }
 }

--- a/processor/src/test/java/com/instagram/common/json/annotation/processor/SerializeTest.java
+++ b/processor/src/test/java/com/instagram/common/json/annotation/processor/SerializeTest.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 
+import com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT;
+import com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT__JsonHelper;
 import com.instagram.common.json.annotation.processor.uut.GetterUUT;
 import com.instagram.common.json.annotation.processor.uut.GetterUUT__JsonHelper;
 import com.instagram.common.json.annotation.processor.uut.EnumUUT;
@@ -352,4 +354,25 @@ public class SerializeTest {
 
     assertEquals(10, parsed.intField);
   }
+
+  @Test
+  public void serializeInterfaceTest() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    JsonGenerator jsonGenerator = new JsonFactory().createGenerator(stringWriter);
+
+    InterfaceImplementationUUT obj = new InterfaceImplementationUUT();
+    obj.mStringField = "testValue";
+
+    WrapperInterfaceUUT wrapper = new WrapperInterfaceUUT();
+    wrapper.mInterfaceParent = obj;
+    WrapperInterfaceUUT__JsonHelper.serializeToJson(jsonGenerator, wrapper, true);
+    jsonGenerator.close();
+    String serialized = stringWriter.toString();
+    WrapperInterfaceUUT parsed = WrapperInterfaceUUT__JsonHelper.parseFromJson(serialized);
+    assertNotNull(parsed);
+    assertTrue(parsed.mInterfaceParent instanceof InterfaceImplementationUUT);
+    InterfaceImplementationUUT parsedObj = (InterfaceImplementationUUT) parsed.mInterfaceParent;
+    assertEquals(obj.mStringField, parsedObj.mStringField);
+  }
+
 }

--- a/processor/src/test/java/com/instagram/common/json/annotation/processor/SerializeTest.java
+++ b/processor/src/test/java/com/instagram/common/json/annotation/processor/SerializeTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT;
 import com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT__JsonHelper;
+import com.instagram.common.json.annotation.processor.parent.InterfaceImplementation2UUT;
 import com.instagram.common.json.annotation.processor.uut.GetterUUT;
 import com.instagram.common.json.annotation.processor.uut.GetterUUT__JsonHelper;
 import com.instagram.common.json.annotation.processor.uut.EnumUUT;
@@ -358,7 +359,7 @@ public class SerializeTest {
   @Test
   public void serializeInterfaceTest() throws IOException {
     StringWriter stringWriter = new StringWriter();
-    JsonGenerator jsonGenerator = new JsonFactory().createGenerator(stringWriter);
+    JsonGenerator jsonGenerator = new JsonFactory().createGenerator(stringWriter);;
 
     InterfaceImplementationUUT obj = new InterfaceImplementationUUT();
     obj.mStringField = "testValue";
@@ -375,4 +376,40 @@ public class SerializeTest {
     assertEquals(obj.mStringField, parsedObj.mStringField);
   }
 
+  @Test
+  public void serializeInterfaceWithWrapperTest() throws IOException {
+    StringWriter stringWriter;
+    JsonGenerator jsonGenerator;
+
+    InterfaceImplementationUUT obj = new InterfaceImplementationUUT();
+    obj.mStringField = "testValue";
+    InterfaceImplementation2UUT obj2 = new InterfaceImplementation2UUT();
+    obj2.mIntegerField = 5;
+
+    WrapperInterfaceUUT wrapper = new WrapperInterfaceUUT();
+
+    stringWriter = new StringWriter();
+    jsonGenerator = new JsonFactory().createGenerator(stringWriter);
+    wrapper.mInterfaceParentWithWrapper = obj;
+    WrapperInterfaceUUT__JsonHelper.serializeToJson(jsonGenerator, wrapper, true);
+    jsonGenerator.close();
+    String serialized = stringWriter.toString();
+    WrapperInterfaceUUT parsed = WrapperInterfaceUUT__JsonHelper.parseFromJson(serialized);
+    assertNotNull(parsed);
+    assertTrue(parsed.mInterfaceParentWithWrapper instanceof InterfaceImplementationUUT);
+    InterfaceImplementationUUT parsedObj = (InterfaceImplementationUUT) parsed.mInterfaceParentWithWrapper;
+    assertEquals(obj.mStringField, parsedObj.mStringField);
+
+    stringWriter = new StringWriter();
+    jsonGenerator = new JsonFactory().createGenerator(stringWriter);
+    wrapper.mInterfaceParentWithWrapper = obj2;
+    WrapperInterfaceUUT__JsonHelper.serializeToJson(jsonGenerator, wrapper, true);
+    jsonGenerator.close();
+    serialized = stringWriter.toString();
+    parsed = WrapperInterfaceUUT__JsonHelper.parseFromJson(serialized);
+    assertNotNull(parsed);
+    assertTrue(parsed.mInterfaceParentWithWrapper instanceof InterfaceImplementation2UUT);
+    InterfaceImplementation2UUT parsedObj2 = (InterfaceImplementation2UUT) parsed.mInterfaceParentWithWrapper;
+    assertEquals(obj2.mIntegerField, parsedObj2.mIntegerField);
+  }
 }

--- a/processor/src/test/java/com/instagram/common/json/annotation/processor/SerializeTest.java
+++ b/processor/src/test/java/com/instagram/common/json/annotation/processor/SerializeTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT;
 import com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT__JsonHelper;
 import com.instagram.common.json.annotation.processor.parent.InterfaceImplementation2UUT;
+import com.instagram.common.json.annotation.processor.parent.InterfaceParentDynamicUUTHelper;
 import com.instagram.common.json.annotation.processor.uut.GetterUUT;
 import com.instagram.common.json.annotation.processor.uut.GetterUUT__JsonHelper;
 import com.instagram.common.json.annotation.processor.uut.EnumUUT;
@@ -432,4 +433,27 @@ public class SerializeTest {
     InterfaceImplementationUUT parsedObj = (InterfaceImplementationUUT) parsed.mInterfaceParentNoFormatters;
     assertEquals(obj.mStringField, parsedObj.mStringField);
   }
+
+  @Test
+  public void serializeInterfaceDynamicTest() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    JsonGenerator jsonGenerator = new JsonFactory().createGenerator(stringWriter);;
+
+    InterfaceImplementationUUT obj = new InterfaceImplementationUUT();
+    obj.mStringField = "testValue";
+
+    InterfaceParentDynamicUUTHelper.DISPATCHER.register(InterfaceImplementationUUT.TYPE_NAME,
+            InterfaceImplementationUUT.ADAPTER);
+    WrapperInterfaceUUT wrapper = new WrapperInterfaceUUT();
+    wrapper.mInterfaceParentDynamic = obj;
+    WrapperInterfaceUUT__JsonHelper.serializeToJson(jsonGenerator, wrapper, true);
+    jsonGenerator.close();
+    String serialized = stringWriter.toString();
+    WrapperInterfaceUUT parsed = WrapperInterfaceUUT__JsonHelper.parseFromJson(serialized);
+    assertNotNull(parsed);
+    assertTrue(parsed.mInterfaceParentDynamic instanceof InterfaceImplementationUUT);
+    InterfaceImplementationUUT parsedObj = (InterfaceImplementationUUT) parsed.mInterfaceParentDynamic;
+    assertEquals(obj.mStringField, parsedObj.mStringField);
+  }
+
 }

--- a/processor/src/test/java/com/instagram/common/json/annotation/processor/SerializeTest.java
+++ b/processor/src/test/java/com/instagram/common/json/annotation/processor/SerializeTest.java
@@ -412,4 +412,24 @@ public class SerializeTest {
     InterfaceImplementation2UUT parsedObj2 = (InterfaceImplementation2UUT) parsed.mInterfaceParentWithWrapper;
     assertEquals(obj2.mIntegerField, parsedObj2.mIntegerField);
   }
+
+  @Test
+  public void serializeInterfaceNoFormattersTest() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    JsonGenerator jsonGenerator = new JsonFactory().createGenerator(stringWriter);;
+
+    InterfaceImplementationUUT obj = new InterfaceImplementationUUT();
+    obj.mStringField = "testValue";
+
+    WrapperInterfaceUUT wrapper = new WrapperInterfaceUUT();
+    wrapper.mInterfaceParentNoFormatters = obj;
+    WrapperInterfaceUUT__JsonHelper.serializeToJson(jsonGenerator, wrapper, true);
+    jsonGenerator.close();
+    String serialized = stringWriter.toString();
+    WrapperInterfaceUUT parsed = WrapperInterfaceUUT__JsonHelper.parseFromJson(serialized);
+    assertNotNull(parsed);
+    assertTrue(parsed.mInterfaceParentNoFormatters instanceof InterfaceImplementationUUT);
+    InterfaceImplementationUUT parsedObj = (InterfaceImplementationUUT) parsed.mInterfaceParentNoFormatters;
+    assertEquals(obj.mStringField, parsedObj.mStringField);
+  }
 }

--- a/processor/testuut/dependent/src/main/java/com/instagram/common/json/annotation/processor/WrapperInterfaceUUT.java
+++ b/processor/testuut/dependent/src/main/java/com/instagram/common/json/annotation/processor/WrapperInterfaceUUT.java
@@ -2,6 +2,7 @@ package com.instagram.common.json.annotation.processor;
 
 import com.instagram.common.json.annotation.JsonField;
 import com.instagram.common.json.annotation.JsonType;
+import com.instagram.common.json.annotation.processor.parent.InterfaceParentNoFormattersUUT;
 import com.instagram.common.json.annotation.processor.parent.InterfaceParentUUT;
 import com.instagram.common.json.annotation.processor.parent.InterfaceParentWithWrapperUUT;
 
@@ -16,4 +17,17 @@ public class WrapperInterfaceUUT {
 
     @JsonField(fieldName = "interface_parent_with_wrapper")
     InterfaceParentWithWrapperUUT mInterfaceParentWithWrapper;
+
+    @JsonField(
+            fieldName = "interface_parent_no_formatters",
+            valueExtractFormatter =
+                    "com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT__JsonHelper"
+                            + ".parseFromJson(${parser_object})",
+            serializeCodeFormatter =
+                    "com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT__JsonHelper"
+                            + ".serializeToJson(${generator_object}, "
+                            + "(com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT)"
+                            + "${object_varname}.${field_varname}, "
+                            + "true)")
+    InterfaceParentNoFormattersUUT mInterfaceParentNoFormatters;
 }

--- a/processor/testuut/dependent/src/main/java/com/instagram/common/json/annotation/processor/WrapperInterfaceUUT.java
+++ b/processor/testuut/dependent/src/main/java/com/instagram/common/json/annotation/processor/WrapperInterfaceUUT.java
@@ -1,0 +1,14 @@
+package com.instagram.common.json.annotation.processor;
+
+import com.instagram.common.json.annotation.JsonField;
+import com.instagram.common.json.annotation.JsonType;
+import com.instagram.common.json.annotation.processor.parent.InterfaceParentUUT;
+
+/**
+ * Wraps {@link com.instagram.common.json.annotation.processor.parent.InterfaceParentUUT}.
+ */
+@JsonType
+public class WrapperInterfaceUUT {
+    @JsonField(fieldName = "interface_parent")
+    InterfaceParentUUT mInterfaceParent;
+}

--- a/processor/testuut/dependent/src/main/java/com/instagram/common/json/annotation/processor/WrapperInterfaceUUT.java
+++ b/processor/testuut/dependent/src/main/java/com/instagram/common/json/annotation/processor/WrapperInterfaceUUT.java
@@ -2,6 +2,7 @@ package com.instagram.common.json.annotation.processor;
 
 import com.instagram.common.json.annotation.JsonField;
 import com.instagram.common.json.annotation.JsonType;
+import com.instagram.common.json.annotation.processor.parent.InterfaceParentDynamicUUT;
 import com.instagram.common.json.annotation.processor.parent.InterfaceParentNoFormattersUUT;
 import com.instagram.common.json.annotation.processor.parent.InterfaceParentUUT;
 import com.instagram.common.json.annotation.processor.parent.InterfaceParentWithWrapperUUT;
@@ -30,4 +31,7 @@ public class WrapperInterfaceUUT {
                             + "${object_varname}.${field_varname}, "
                             + "true)")
     InterfaceParentNoFormattersUUT mInterfaceParentNoFormatters;
+
+    @JsonField(fieldName = "interface_parent_dynamic")
+    InterfaceParentDynamicUUT mInterfaceParentDynamic;
 }

--- a/processor/testuut/dependent/src/main/java/com/instagram/common/json/annotation/processor/WrapperInterfaceUUT.java
+++ b/processor/testuut/dependent/src/main/java/com/instagram/common/json/annotation/processor/WrapperInterfaceUUT.java
@@ -3,12 +3,17 @@ package com.instagram.common.json.annotation.processor;
 import com.instagram.common.json.annotation.JsonField;
 import com.instagram.common.json.annotation.JsonType;
 import com.instagram.common.json.annotation.processor.parent.InterfaceParentUUT;
+import com.instagram.common.json.annotation.processor.parent.InterfaceParentWithWrapperUUT;
+
 
 /**
- * Wraps {@link com.instagram.common.json.annotation.processor.parent.InterfaceParentUUT}.
+ * Wrapper for interface tests.
  */
 @JsonType
 public class WrapperInterfaceUUT {
     @JsonField(fieldName = "interface_parent")
     InterfaceParentUUT mInterfaceParent;
+
+    @JsonField(fieldName = "interface_parent_with_wrapper")
+    InterfaceParentWithWrapperUUT mInterfaceParentWithWrapper;
 }

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/DynamicDispatchAdapter.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/DynamicDispatchAdapter.java
@@ -1,0 +1,76 @@
+package com.instagram.common.json.annotation.processor.parent;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import javax.annotation.Nullable;
+
+public class DynamicDispatchAdapter<T extends DynamicDispatchAdapter.TypeNameProvider> {
+    public interface TypeNameProvider {
+        public String getTypeName();
+    }
+
+    public interface TypeAdapter<T> {
+        void serializeToJson(JsonGenerator generator, T object) throws IOException;
+        T parseFromJson(JsonParser parser) throws IOException;
+    }
+
+    private HashMap<String,TypeAdapter<T>> mAdapterMap = new HashMap<>();
+
+    public void register(String typeName, TypeAdapter<T> adapter) {
+        if (mAdapterMap.containsKey(typeName)) {
+            String message = String.format(
+                    "Duplicate handler name. %s is already mapped to an instance of %s",
+                    typeName,
+                    mAdapterMap.get(typeName));
+            throw new IllegalArgumentException(message);
+        }
+        mAdapterMap.put(typeName, adapter);
+    }
+
+    public void unregister(String typeName) {
+        mAdapterMap.remove(typeName);
+    }
+
+    public T parseFromJson(JsonParser parser) throws IOException {
+        if (parser.getCurrentToken() != JsonToken.START_ARRAY) {
+            parser.skipChildren();
+            return null;
+        }
+
+        parser.nextToken();
+        if (parser.getCurrentToken() != JsonToken.VALUE_STRING) {
+            parser.skipChildren();
+            return null;
+        }
+
+        String typeName = parser.getText();
+        parser.nextToken();
+        final T instance = getAdapter(typeName).parseFromJson(parser);
+        parser.nextToken();
+        return instance;
+    }
+
+    private TypeAdapter<T> getAdapter(String typeName) {
+        final @Nullable TypeAdapter<T> adapter = mAdapterMap.get(typeName);
+        if (adapter == null) {
+            final String message = String.format(
+                    "No TypeAdapter registered for type name: %s",
+                    typeName);
+            throw new IllegalArgumentException(message);
+        }
+
+        return adapter;
+    }
+
+    public void serialize(JsonGenerator generator, String fieldName, T object) throws IOException {
+        generator.writeStartArray();
+        generator.writeString(object.getTypeName());
+        getAdapter(object.getTypeName()).serializeToJson(generator, object);
+        generator.writeEndArray();
+    }
+}

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/DynamicDispatchAdapter.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/DynamicDispatchAdapter.java
@@ -67,7 +67,7 @@ public class DynamicDispatchAdapter<T extends DynamicDispatchAdapter.TypeNamePro
         return adapter;
     }
 
-    public void serialize(JsonGenerator generator, String fieldName, T object) throws IOException {
+    public void serializeToJson(JsonGenerator generator, T object) throws IOException {
         generator.writeStartArray();
         generator.writeString(object.getTypeName());
         getAdapter(object.getTypeName()).serializeToJson(generator, object);

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceImplementation2UUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceImplementation2UUT.java
@@ -1,0 +1,13 @@
+package com.instagram.common.json.annotation.processor.parent;
+
+import com.instagram.common.json.annotation.JsonField;
+import com.instagram.common.json.annotation.JsonType;
+
+/**
+ * A second implementation of {@link com.instagram.common.json.annotation.processor.parent.InterfaceParentWithWrapperUUT}.
+ */
+@JsonType
+public class InterfaceImplementation2UUT implements InterfaceParentWithWrapperUUT {
+    @JsonField(fieldName = "integer_field")
+    public int mIntegerField;
+}

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceImplementationUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceImplementationUUT.java
@@ -1,0 +1,10 @@
+package com.instagram.common.json.annotation.processor.parent;
+
+import com.instagram.common.json.annotation.JsonField;
+import com.instagram.common.json.annotation.JsonType;
+
+@JsonType
+public class InterfaceImplementationUUT implements InterfaceParentUUT {
+    @JsonField(fieldName = "stringField")
+    public String mStringField;
+}

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceImplementationUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceImplementationUUT.java
@@ -8,7 +8,7 @@ import com.instagram.common.json.annotation.JsonType;
  */
 @JsonType
 public class InterfaceImplementationUUT implements InterfaceParentUUT,
-        InterfaceParentWithWrapperUUT {
+        InterfaceParentWithWrapperUUT, InterfaceParentNoFormattersUUT {
     @JsonField(fieldName = "stringField")
     public String mStringField;
 }

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceImplementationUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceImplementationUUT.java
@@ -3,6 +3,9 @@ package com.instagram.common.json.annotation.processor.parent;
 import com.instagram.common.json.annotation.JsonField;
 import com.instagram.common.json.annotation.JsonType;
 
+/**
+ * A default interface implementation.
+ */
 @JsonType
 public class InterfaceImplementationUUT implements InterfaceParentUUT {
     @JsonField(fieldName = "stringField")

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceImplementationUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceImplementationUUT.java
@@ -7,7 +7,8 @@ import com.instagram.common.json.annotation.JsonType;
  * A default interface implementation.
  */
 @JsonType
-public class InterfaceImplementationUUT implements InterfaceParentUUT {
+public class InterfaceImplementationUUT implements InterfaceParentUUT,
+        InterfaceParentWithWrapperUUT {
     @JsonField(fieldName = "stringField")
     public String mStringField;
 }

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceImplementationUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceImplementationUUT.java
@@ -1,14 +1,39 @@
 package com.instagram.common.json.annotation.processor.parent;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
 import com.instagram.common.json.annotation.JsonField;
 import com.instagram.common.json.annotation.JsonType;
+
+import java.io.IOException;
 
 /**
  * A default interface implementation.
  */
 @JsonType
 public class InterfaceImplementationUUT implements InterfaceParentUUT,
-        InterfaceParentWithWrapperUUT, InterfaceParentNoFormattersUUT {
+        InterfaceParentWithWrapperUUT, InterfaceParentNoFormattersUUT,
+        InterfaceParentDynamicUUT {
+    public static final String TYPE_NAME = "InterfaceImplementationUUT";
+    public static final DynamicDispatchAdapter.TypeAdapter<InterfaceParentDynamicUUT> ADAPTER =
+            new DynamicDispatchAdapter.TypeAdapter<InterfaceParentDynamicUUT>() {
+                @Override
+                public void serializeToJson(JsonGenerator generator, InterfaceParentDynamicUUT object) throws IOException {
+                    InterfaceImplementationUUT__JsonHelper
+                            .serializeToJson(generator, (InterfaceImplementationUUT)object, true);
+                }
+
+                @Override
+                public InterfaceParentDynamicUUT parseFromJson(JsonParser parser) throws IOException {
+                    return InterfaceImplementationUUT__JsonHelper.parseFromJson(parser);
+                }
+            };
+
     @JsonField(fieldName = "stringField")
     public String mStringField;
+
+    @Override
+    public String getTypeName() {
+        return TYPE_NAME;
+    }
 }

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentDynamicUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentDynamicUUT.java
@@ -1,0 +1,11 @@
+package com.instagram.common.json.annotation.processor.parent;
+
+import com.instagram.common.json.annotation.JsonType;
+
+@JsonType(
+        serializeCodeFormatter = "com.instagram.common.json.annotation.processor.parent.InterfaceParentDynamicUUTHelper.DISPATCHER.serializeToJson("
+            + "${generator_object}, ${object_varname}.${field_varname})",
+        valueExtractFormatter = "com.instagram.common.json.annotation.processor.parent.InterfaceParentDynamicUUTHelper.DISPATCHER.parseFromJson("
+            + "${parser_object})")
+public interface InterfaceParentDynamicUUT extends DynamicDispatchAdapter.TypeNameProvider {
+}

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentDynamicUUTHelper.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentDynamicUUTHelper.java
@@ -1,0 +1,6 @@
+package com.instagram.common.json.annotation.processor.parent;
+
+public class InterfaceParentDynamicUUTHelper {
+    public static final DynamicDispatchAdapter<InterfaceParentDynamicUUT> DISPATCHER =
+            new DynamicDispatchAdapter<>();
+}

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentNoFormattersUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentNoFormattersUUT.java
@@ -1,0 +1,11 @@
+package com.instagram.common.json.annotation.processor.parent;
+
+import com.instagram.common.json.annotation.JsonType;
+
+/**
+ * An interface to verify that serialization/parsing can work without formatters
+ * on the interface itself.
+ */
+@JsonType
+public interface InterfaceParentNoFormattersUUT {
+}

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentUUT.java
@@ -7,7 +7,7 @@ import com.instagram.common.json.annotation.JsonType;
  */
 @JsonType(
         valueExtractFormatter =
-                "com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT__JsonHelper"
+        "com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT__JsonHelper"
                 + ".parseFromJson(${parser_object})",
         serializeCodeFormatter =
                 "com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT__JsonHelper"

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentUUT.java
@@ -11,6 +11,9 @@ import com.instagram.common.json.annotation.JsonType;
                 + ".parseFromJson(${parser_object})",
         serializeCodeFormatter =
                 "com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT__JsonHelper"
-                + ".serializeToJson(${generator_object}, (com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT)${object_varname}.${field_varname}, true)")
+                + ".serializeToJson(${generator_object}, "
+                + "(com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT)"
+                + "${object_varname}.${field_varname}, "
+                + "true)")
 public interface InterfaceParentUUT {
 }

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentUUT.java
@@ -1,0 +1,16 @@
+package com.instagram.common.json.annotation.processor.parent;
+
+import com.instagram.common.json.annotation.JsonType;
+
+/**
+ * Interface parent to test that polymorphic deserialization works.
+ */
+@JsonType(
+        valueExtractFormatter =
+                "com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT__JsonHelper"
+                + ".parseFromJson(${parser_object})",
+        serializeCodeFormatter =
+                "com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT__JsonHelper"
+                + ".serializeToJson(${generator_object}, (com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT)${object_varname}.${field_varname}, true)")
+public interface InterfaceParentUUT {
+}

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentWithWrapperUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentWithWrapperUUT.java
@@ -1,0 +1,20 @@
+package com.instagram.common.json.annotation.processor.parent;
+
+import com.instagram.common.json.annotation.JsonType;
+
+/**
+ * An interface parent that performs static-ish dispatch with a wrapper class.
+ */
+@JsonType(
+        valueExtractFormatter =
+                "com.instagram.common.json.annotation.processor.parent.InterfaceParentWrapperUUT__JsonHelper"
+                        + ".parseFromJson(${parser_object}).getInterfaceParentWithWrapperUUT()",
+        serializeCodeFormatter =
+                "com.instagram.common.json.annotation.processor.parent.InterfaceParentWrapperUUT__JsonHelper"
+                        + ".serializeToJson(${generator_object}, "
+                        + "com.instagram.common.json.annotation.processor.parent.InterfaceParentWrapperUUT.from("
+                        + ""
+                        + "${object_varname}.${field_varname}), "
+                        + "true)")
+public interface InterfaceParentWithWrapperUUT {
+}

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentWrapperUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentWrapperUUT.java
@@ -1,0 +1,38 @@
+package com.instagram.common.json.annotation.processor.parent;
+
+import com.instagram.common.json.annotation.JsonField;
+import com.instagram.common.json.annotation.JsonType;
+
+@JsonType
+public class InterfaceParentWrapperUUT {
+    @JsonField(fieldName = "implementation1")
+    InterfaceImplementationUUT mImplementation1;
+
+    @JsonField(fieldName = "implementation2")
+    InterfaceImplementation2UUT mImplementation2;
+
+    public static InterfaceParentWrapperUUT from(InterfaceParentWithWrapperUUT instance) {
+        InterfaceParentWrapperUUT wrapper = new InterfaceParentWrapperUUT();
+
+        if (instance instanceof InterfaceImplementationUUT) {
+            wrapper.mImplementation1 = (InterfaceImplementationUUT) instance;
+        } else if (instance instanceof InterfaceImplementation2UUT) {
+            wrapper.mImplementation2 = (InterfaceImplementation2UUT) instance;
+        } else {
+            throw new IllegalArgumentException("Unknown interface implementation: "
+                    + instance.getClass().getName());
+        }
+
+        return wrapper;
+    }
+
+    public InterfaceParentWithWrapperUUT getInterfaceParentWithWrapperUUT() {
+        if (mImplementation1 != null) {
+            return mImplementation1;
+        } else if (mImplementation2 != null) {
+            return mImplementation2;
+        } else {
+            return null;
+        }
+    }
+}

--- a/util/src/main/java/com/instagram/common/json/annotation/util/TypeUtils.java
+++ b/util/src/main/java/com/instagram/common/json/annotation/util/TypeUtils.java
@@ -2,6 +2,7 @@
 
 package com.instagram.common.json.annotation.util;
 
+import javax.annotation.Nullable;
 import javax.annotation.processing.Messager;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -156,6 +157,7 @@ public class TypeUtils {
    * Returns null if {@code typeMirror} does not represent a list type or if we cannot divine the
    * type of the contents.
    */
+  @Nullable
   public TypeMirror getCollectionParameterizedType(TypeMirror typeMirror) {
     if (!(typeMirror instanceof DeclaredType)) {
       return null;
@@ -213,6 +215,7 @@ public class TypeUtils {
    * To make this work, we replace the normal dot notation between an outer class and an inner class
    * with a '_', i.e., the generated class for class X will be X_Y&lt;suffix&gt;.
    */
+  @Nullable
   public String getPrefixForGeneratedClass(TypeElement type, String packageName) {
     // Interfaces do not currently generate classes
     if (type.getKind() == INTERFACE) {

--- a/util/src/main/java/com/instagram/common/json/annotation/util/TypeUtils.java
+++ b/util/src/main/java/com/instagram/common/json/annotation/util/TypeUtils.java
@@ -4,6 +4,7 @@ package com.instagram.common.json.annotation.util;
 
 import javax.annotation.processing.Messager;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.DeclaredType;
@@ -13,7 +14,11 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 import java.lang.annotation.Annotation;
+import java.util.EnumSet;
 import java.util.List;
+
+import static javax.lang.model.element.ElementKind.CLASS;
+import static javax.lang.model.element.ElementKind.INTERFACE;
 
 /**
  * Utility functions to get the declared types of fields.
@@ -103,7 +108,7 @@ public class TypeUtils {
       Element element = type.asElement();
 
       Annotation annotation = element.getAnnotation(typeAnnotationClass);
-      if (annotation != null) {
+      if (annotation != null && EnumSet.of(CLASS, INTERFACE).contains(element.getKind())) {
         return ParseType.PARSABLE_OBJECT;
       }
 
@@ -209,6 +214,10 @@ public class TypeUtils {
    * with a '_', i.e., the generated class for class X will be X_Y&lt;suffix&gt;.
    */
   public String getPrefixForGeneratedClass(TypeElement type, String packageName) {
+    // Interfaces do not currently generate classes
+    if (type.getKind() == INTERFACE) {
+      return null;
+    }
     int packageLen = packageName.length() + 1;
     return type.getQualifiedName().toString().substring(packageLen).replace('.', '_');
   }


### PR DESCRIPTION
Per discussion on #50, here is a dramatically stripped down implementation. 

This adds support for `serializeCodeFormatter` on `JsonType` for all types, and allows `JsonType` to annotate interfaces. Interfaces will not generate a JsonHelper implementation, but they can be referred to by other parsers.