### PR TITLE
Add subobject name serializer param

### DIFF
--- a/common/src/main/java/com/instagram/common/json/annotation/JsonField.java
+++ b/common/src/main/java/com/instagram/common/json/annotation/JsonField.java
@@ -129,6 +129,10 @@ public @interface JsonField {
    *   <li>
    *     ${subobject_helper_class}: the class that is responsible for serializing the current field
    *   </li>
+   *   <li>
+   *     ${subobject}: reference to the subobject being parsed. Equivalent to either
+   *     ${object_varname}.${field_varname} or ${iterator}, depending on context.
+   *   </li>
    * </ul>
    * <p/>
    * The formatting tokens are not always valid, depending on the nature of the field being
@@ -142,6 +146,7 @@ public @interface JsonField {
    *     <th>${iterator}</th>
    *     <th>${json_fieldname}</th>
    *     <th>${subobject_helper_class}</th>
+   *     <th>${subobject}</th>
    *   </tr>
    *   <tr>
    *     <th>Scalars</th>
@@ -150,6 +155,7 @@ public @interface JsonField {
    *     <td>&#x2714;</td>
    *     <td>&#x2717;</td>
    *     <td>&#x2714;</td>
+   *     <td>&#x2717;</td>
    *     <td>&#x2717;</td>
    *   </tr>
    *   <tr>
@@ -160,6 +166,7 @@ public @interface JsonField {
    *     <td>&#x2717;</td>
    *     <td>&#x2717;</td>
    *     <td>&#x2714;</td>
+   *     <td>&#x2714;</td>
    *   </tr>
    *   <tr>
    *     <th>List of scalars</th>
@@ -167,6 +174,7 @@ public @interface JsonField {
    *     <td>&#x2717;</td>
    *     <td>&#x2717;</td>
    *     <td>&#x2714;</td>
+   *     <td>&#x2717;</td>
    *     <td>&#x2717;</td>
    *     <td>&#x2717;</td>
    *   </tr>
@@ -177,6 +185,7 @@ public @interface JsonField {
    *     <td>&#x2717;</td>
    *     <td>&#x2714;</td>
    *     <td>&#x2717;</td>
+   *     <td>&#x2714;</td>
    *     <td>&#x2714;</td>
    *   </tr>
    * </table>

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
@@ -635,7 +635,6 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
                   .addParam("object_varname", "object")
                   .addParam("field_varname", member)
                   .addParam("json_fieldname", data.getFieldName())
-                  .addParam("subobject", "object." + member)
                   .format();
 
           switch (data.getParseType()) {
@@ -661,13 +660,16 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
   private String getMapSerializeCodeStatement(TypeData valueTypeData, String valueSerializeCode) {
     StrFormat strFormat = StrFormat.createStringFormatter(valueSerializeCode)
             .addParam("generator_object", "generator")
-            .addParam("iterator", "entry.getValue()")
-            .addParam("subobject", "entry.getValue()");
-    if (!StringUtil.isNullOrEmpty(valueTypeData.getParsableTypeParserClass())) {
+            .addParam("iterator", "entry.getValue()");
+
+    if (valueTypeData.hasParserHelperClass()) {
       strFormat.addParam(
               "subobject_helper_class",
               valueTypeData.getParsableTypeParserClass() +
                       JsonAnnotationProcessorConstants.HELPER_CLASS_SUFFIX);
+    }
+    if (valueTypeData.getParseType() == TypeUtils.ParseType.PARSABLE_OBJECT) {
+      strFormat.addParam("subobject", "entry.getValue()");
     }
 
     return strFormat.format();

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
@@ -558,6 +558,7 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
                       "subobject_helper_class",
                       data.getParsableTypeParserClass() +
                           JsonAnnotationProcessorConstants.HELPER_CLASS_SUFFIX)
+                  .addParam("subobject", "element")
                   .format())
               .endControlFlow()
               .endControlFlow()
@@ -591,7 +592,7 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
               .beginControlFlow("if (entry.getValue() == null)")
               .emitStatement("generator.writeNull()")
               .nextControlFlow("else")
-              .emitStatement(getSerializeCodeStatement(valueTypeData, valueSerializeCode))
+              .emitStatement(getMapSerializeCodeStatement(valueTypeData, valueSerializeCode))
               .endControlFlow()
               .endControlFlow()
               .emitStatement("generator.writeEndObject()")
@@ -625,6 +626,7 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
                       .addParam("subobject_helper_class",
                           data.getParsableTypeParserClass() +
                               JsonAnnotationProcessorConstants.HELPER_CLASS_SUFFIX)
+                      .addParam("subobject", "object." + member)
                       .format())
               .endControlFlow();
         } else {
@@ -638,6 +640,7 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
                   .addParam("object_varname", "object")
                   .addParam("field_varname", member)
                   .addParam("json_fieldname", data.getFieldName())
+                  .addParam("subobject", "object." + member)
                   .format();
 
           switch (data.getParseType()) {
@@ -660,10 +663,11 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
     }
   }
 
-  private String getSerializeCodeStatement(TypeData valueTypeData, String valueSerializeCode) {
+  private String getMapSerializeCodeStatement(TypeData valueTypeData, String valueSerializeCode) {
     StrFormat strFormat = StrFormat.createStringFormatter(valueSerializeCode)
             .addParam("generator_object", "generator")
-            .addParam("iterator", "entry.getValue()");
+            .addParam("iterator", "entry.getValue()")
+            .addParam("subobject", "entry.getValue()");
     if (!StringUtil.isNullOrEmpty(valueTypeData.getParsableTypeParserClass())) {
       strFormat.addParam(
               "subobject_helper_class",

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
@@ -98,18 +98,13 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
       Set<String> typeImports = new HashSet<String>();
       for (Map.Entry<String, TypeData> entry : getIterator()) {
         TypeData typeData = entry.getValue();
-        if (typeData.getCollectionType() != TypeUtils.CollectionType.NOT_A_COLLECTION) {
-          if (typeData.needsImportFrom(mClassPackage)) {
-            typeImports.add(typeData.getPackageName() + "." + typeData.getParsableType());
+        if (typeData.needsImportFrom(mClassPackage)) {
+          typeImports.add(typeData.getPackageName() + "." + typeData.getParsableType());
+          if (typeData.hasParserHelperClass()) {
             typeImports.add(
                 typeData.getPackageName() + "." + typeData.getParsableTypeParserClass() +
                     JsonAnnotationProcessorConstants.HELPER_CLASS_SUFFIX);
           }
-        } else if (typeData.needsImportFrom(mClassPackage)) {
-          typeImports.add(
-              typeData.getPackageName() + "." + typeData.getParsableTypeParserClass() +
-                  JsonAnnotationProcessorConstants.HELPER_CLASS_SUFFIX);
-          typeImports.add(typeData.getPackageName() + "." + typeData.getParsableType());
         }
       }
       writer.emitImports(typeImports);

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/TypeData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/TypeData.java
@@ -185,8 +185,11 @@ class TypeData {
 
   public boolean needsImportFrom(String packageName) {
     return getParseType() == TypeUtils.ParseType.PARSABLE_OBJECT &&
-            !getPackageName().equals(packageName) &&
-            !StringUtil.isNullOrEmpty(getParsableTypeParserClass());
+            !getPackageName().equals(packageName);
+  }
+
+  public boolean hasParserHelperClass() {
+    return !StringUtil.isNullOrEmpty(getParsableTypeParserClass());
   }
 
   public void setIsInterface(boolean isInterface) {

--- a/processor/testuut/dependent/src/main/java/com/instagram/common/json/annotation/processor/WrapperInterfaceUUT.java
+++ b/processor/testuut/dependent/src/main/java/com/instagram/common/json/annotation/processor/WrapperInterfaceUUT.java
@@ -7,6 +7,8 @@ import com.instagram.common.json.annotation.processor.parent.InterfaceParentNoFo
 import com.instagram.common.json.annotation.processor.parent.InterfaceParentUUT;
 import com.instagram.common.json.annotation.processor.parent.InterfaceParentWithWrapperUUT;
 
+import java.util.List;
+
 
 /**
  * Wrapper for interface tests.
@@ -34,4 +36,7 @@ public class WrapperInterfaceUUT {
 
     @JsonField(fieldName = "interface_parent_dynamic")
     InterfaceParentDynamicUUT mInterfaceParentDynamic;
+
+    @JsonField(fieldName = "interface_parent_list")
+    List<InterfaceParentUUT> mInterfaceParentList;
 }

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentDynamicUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentDynamicUUT.java
@@ -4,7 +4,7 @@ import com.instagram.common.json.annotation.JsonType;
 
 @JsonType(
         serializeCodeFormatter = "com.instagram.common.json.annotation.processor.parent.InterfaceParentDynamicUUTHelper.DISPATCHER.serializeToJson("
-            + "${generator_object}, ${object_varname}.${field_varname})",
+            + "${generator_object}, ${subobject})",
         valueExtractFormatter = "com.instagram.common.json.annotation.processor.parent.InterfaceParentDynamicUUTHelper.DISPATCHER.parseFromJson("
             + "${parser_object})")
 public interface InterfaceParentDynamicUUT extends DynamicDispatchAdapter.TypeNameProvider {

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentUUT.java
@@ -13,7 +13,7 @@ import com.instagram.common.json.annotation.JsonType;
                 "com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT__JsonHelper"
                 + ".serializeToJson(${generator_object}, "
                 + "(com.instagram.common.json.annotation.processor.parent.InterfaceImplementationUUT)"
-                + "${object_varname}.${field_varname}, "
+                + "${subobject}, "
                 + "true)")
 public interface InterfaceParentUUT {
 }

--- a/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentWithWrapperUUT.java
+++ b/processor/testuut/parent/src/main/java/com/instagram/common/json/annotation/processor/InterfaceParentWithWrapperUUT.java
@@ -14,7 +14,7 @@ import com.instagram.common.json.annotation.JsonType;
                         + ".serializeToJson(${generator_object}, "
                         + "com.instagram.common.json.annotation.processor.parent.InterfaceParentWrapperUUT.from("
                         + ""
-                        + "${object_varname}.${field_varname}), "
+                        + "${subobject}), "
                         + "true)")
 public interface InterfaceParentWithWrapperUUT {
 }


### PR DESCRIPTION
Adds a `${subobject}` parameter for `serializeCodeFormatter`. For objects, this parameter is equivalent to `${object_varname}.${field_varname}` in a field context, or `${iterator}` in a collection context.

This is much needed by the interface PR; without a feature like this, it's impossible to write one `serializeCodeFormatter` that can be used in both collections and field references.

If a better name is possible for this parameter, it can easily be extended to scalars, since the idea is the same. But with the name `${subobject}`, those did not seem to be appropriate semantics.

This PR also includes a fix in import generation in `JsonParserClassData.getJsonCode` that was breaking list references in the test code.