### PR TITLE
Filter token expansion for serializeCodeFormatter

### DIFF
--- a/common/src/main/java/com/instagram/common/json/annotation/JsonField.java
+++ b/common/src/main/java/com/instagram/common/json/annotation/JsonField.java
@@ -146,7 +146,6 @@ public @interface JsonField {
    *     <th>${iterator}</th>
    *     <th>${json_fieldname}</th>
    *     <th>${subobject_helper_class}</th>
-   *     <th>${subobject}</th>
    *   </tr>
    *   <tr>
    *     <th>Scalars</th>
@@ -155,7 +154,6 @@ public @interface JsonField {
    *     <td>&#x2714;</td>
    *     <td>&#x2717;</td>
    *     <td>&#x2714;</td>
-   *     <td>&#x2717;</td>
    *     <td>&#x2717;</td>
    *   </tr>
    *   <tr>
@@ -166,7 +164,6 @@ public @interface JsonField {
    *     <td>&#x2717;</td>
    *     <td>&#x2717;</td>
    *     <td>&#x2714;</td>
-   *     <td>&#x2714;</td>
    *   </tr>
    *   <tr>
    *     <th>List of scalars</th>
@@ -174,7 +171,6 @@ public @interface JsonField {
    *     <td>&#x2717;</td>
    *     <td>&#x2717;</td>
    *     <td>&#x2714;</td>
-   *     <td>&#x2717;</td>
    *     <td>&#x2717;</td>
    *     <td>&#x2717;</td>
    *   </tr>
@@ -185,7 +181,6 @@ public @interface JsonField {
    *     <td>&#x2717;</td>
    *     <td>&#x2714;</td>
    *     <td>&#x2717;</td>
-   *     <td>&#x2714;</td>
    *     <td>&#x2714;</td>
    *   </tr>
    * </table>

--- a/common/src/main/java/com/instagram/common/json/annotation/JsonType.java
+++ b/common/src/main/java/com/instagram/common/json/annotation/JsonType.java
@@ -72,6 +72,22 @@ public @interface JsonType {
    * is referenced in a serializer without either {@link JsonType}'s {@link JsonType#serializeCodeFormatter()}
    * or {@link JsonField#serializeCodeFormatter()} provided.
    *
+   * <p>Valid formatting tokens:</p>
+   *
+   * <ul>
+   *   <li>
+   *     ${generator_object}: the name of the variable holding the reference to the json generator
+   *     object
+   *   </li>
+   *   <li>
+   *    ${subobject}: a reference to the instance being serialized
+   *   </li>
+   *   <li>
+   *     ${subobject_helper_class}: name of the subobject's JsonHelper class. Not valid for
+   *     interfaces.
+   *   </li>
+   * </ul>
+   *
    * <p> See {@link JsonField#serializeCodeFormatter()} for more details.
    *
    * @return

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/CodeFormatter.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/CodeFormatter.java
@@ -20,11 +20,11 @@ public class CodeFormatter {
 
   private final String mFormatterString;
 
-  private final Set<String> mSupportedParameters;
+  private final Set<String> mSupportedTokens;
 
-  private CodeFormatter(String formatterString, Set<String> supportedParameters) {
+  private CodeFormatter(String formatterString, Set<String> supportedTokens) {
     mFormatterString = formatterString;
-    mSupportedParameters = supportedParameters;
+    mSupportedTokens = supportedTokens;
   }
 
   public boolean isEmpty() {
@@ -43,24 +43,24 @@ public class CodeFormatter {
     }
   }
 
-  public Set<String> getSupportedParameters() {
-    return mSupportedParameters;
+  public Set<String> getSupportedTokens() {
+    return mSupportedTokens;
   }
 
   public static class Factory {
-    private Set<String> mSupportedParameters;
+    private Set<String> mSupportedTokens;
 
-    private Factory(String... supportedParameters) {
-      if (supportedParameters != null && supportedParameters.length > 0) {
-        mSupportedParameters = new HashSet<>(Arrays.asList(supportedParameters));
+    private Factory(String... supportedTokens) {
+      if (supportedTokens != null && supportedTokens.length > 0) {
+        mSupportedTokens = new HashSet<>(Arrays.asList(supportedTokens));
       } else {
-        mSupportedParameters = Collections.emptySet();
+        mSupportedTokens = Collections.emptySet();
       }
 
     }
 
     public CodeFormatter forString(String formatterString) {
-      return new CodeFormatter(formatterString, mSupportedParameters);
+      return new CodeFormatter(formatterString, mSupportedTokens);
     }
   }
 }

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/CodeFormatter.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/CodeFormatter.java
@@ -1,0 +1,66 @@
+package com.instagram.common.json.annotation.processor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class CodeFormatter {
+  public static final Factory VALUE_EXTRACT = new Factory(
+      "parser_object", "subobject_class", "subobject_helper_class");
+  public static final Factory FIELD_ASSIGNMENT = new Factory(
+      "object_varname", "field_varname", "extracted_value");
+  public static final Factory FIELD_CODE_SERIALIZATION = new Factory(
+      "generator_object", "object_varname", "field_varname", "iterator",
+      "json_fieldname", "subobject_helper_class");
+  public static final Factory CLASS_CODE_SERIALIZATION = new Factory(
+      "generator_object", "subobject", "subobject_helper_class");
+  public static final Factory INTERFACE_CODE_SERIALIZATION = new Factory(
+      "generator_object", "subobject");
+
+  private final String mFormatterString;
+
+  private final Set<String> mSupportedParameters;
+
+  private CodeFormatter(String formatterString, Set<String> supportedParameters) {
+    mFormatterString = formatterString;
+    mSupportedParameters = supportedParameters;
+  }
+
+  public boolean isEmpty() {
+    return StringUtil.isNullOrEmpty(mFormatterString);
+  }
+
+  public String getFormatterString() {
+    return mFormatterString;
+  }
+
+  public CodeFormatter orIfEmpty(CodeFormatter defaultFormatter) {
+    if (isEmpty()) {
+      return defaultFormatter;
+    } else {
+      return this;
+    }
+  }
+
+  public Set<String> getSupportedParameters() {
+    return mSupportedParameters;
+  }
+
+  public static class Factory {
+    private Set<String> mSupportedParameters;
+
+    private Factory(String... supportedParameters) {
+      if (supportedParameters != null && supportedParameters.length > 0) {
+        mSupportedParameters = new HashSet<>(Arrays.asList(supportedParameters));
+      } else {
+        mSupportedParameters = Collections.emptySet();
+      }
+
+    }
+
+    public CodeFormatter forString(String formatterString) {
+      return new CodeFormatter(formatterString, mSupportedParameters);
+    }
+  }
+}

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/StrFormat.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/StrFormat.java
@@ -3,7 +3,9 @@
 package com.instagram.common.json.annotation.processor;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.lang3.text.StrSubstitutor;
 
@@ -11,16 +13,20 @@ import org.apache.commons.lang3.text.StrSubstitutor;
  * Syntactic sugar wrapper for {@link StrSubstitutor}.
  */
 class StrFormat {
-  private String mFormatString;
-  private Map<String, String> mInternalMap;
+  private final String mFormatString;
+  private final Map<String, String> mInternalMap;
+  private final Set<String> mSupportedParameters;
 
-  StrFormat(String formatString) {
+  private StrFormat(String formatString, Set<String> supportedParameters) {
     mFormatString = formatString;
     mInternalMap = new HashMap<String, String>();
+    mSupportedParameters = supportedParameters;
   }
 
   StrFormat addParam(String variableName, String replacementText) {
-    mInternalMap.put(variableName, replacementText);
+    if (mSupportedParameters.contains(variableName)) {
+      mInternalMap.put(variableName, replacementText);
+    }
     return this;
   }
 
@@ -28,7 +34,9 @@ class StrFormat {
     return StrSubstitutor.replace(mFormatString, mInternalMap);
   }
 
-  static StrFormat createStringFormatter(String formatString) {
-    return new StrFormat(formatString);
+  static StrFormat createStringFormatter(CodeFormatter formatter) {
+    return new StrFormat(
+        formatter.getFormatterString(),
+        formatter.getSupportedParameters());
   }
 }

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/StrFormat.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/StrFormat.java
@@ -3,7 +3,6 @@
 package com.instagram.common.json.annotation.processor;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -15,16 +14,16 @@ import org.apache.commons.lang3.text.StrSubstitutor;
 class StrFormat {
   private final String mFormatString;
   private final Map<String, String> mInternalMap;
-  private final Set<String> mSupportedParameters;
+  private final Set<String> mSupportedTokens;
 
-  private StrFormat(String formatString, Set<String> supportedParameters) {
+  private StrFormat(String formatString, Set<String> supportedTokens) {
     mFormatString = formatString;
     mInternalMap = new HashMap<String, String>();
-    mSupportedParameters = supportedParameters;
+    mSupportedTokens = supportedTokens;
   }
 
   StrFormat addParam(String variableName, String replacementText) {
-    if (mSupportedParameters.contains(variableName)) {
+    if (mSupportedTokens.contains(variableName)) {
       mInternalMap.put(variableName, replacementText);
     }
     return this;
@@ -37,6 +36,6 @@ class StrFormat {
   static StrFormat createStringFormatter(CodeFormatter formatter) {
     return new StrFormat(
         formatter.getFormatterString(),
-        formatter.getSupportedParameters());
+        formatter.getSupportedTokens());
   }
 }

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/TypeData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/TypeData.java
@@ -32,17 +32,17 @@ class TypeData {
   /**
    * {@link JsonField#valueExtractFormatter()}
    */
-  private String mValueExtractFormatter;
+  private CodeFormatter mValueExtractFormatter;
 
   /**
    * {@link JsonField#fieldAssignmentFormatter()}
    */
-  private String mAssignmentFormatter;
+  private CodeFormatter mAssignmentFormatter;
 
   /**
    * {@link JsonField#serializeCodeFormatter()}
    */
-  private String mSerializeCodeFormatter;
+  private CodeFormatter mSerializeCodeFormatter;
 
   /**
    * The collection type of the field, if the field is a collection, otherwise it is set to
@@ -105,27 +105,27 @@ class TypeData {
     this.mMapping = mapping;
   }
 
-  public String getValueExtractFormatter() {
+  public CodeFormatter getValueExtractFormatter() {
     return mValueExtractFormatter;
   }
 
-  public void setValueExtractFormatter(String valueExtractFormatter) {
-    mValueExtractFormatter = valueExtractFormatter;
+  public void setValueExtractFormatter(CodeFormatter codeFormatter) {
+    mValueExtractFormatter = codeFormatter;
   }
 
-  public String getAssignmentFormatter() {
+  public CodeFormatter getAssignmentFormatter() {
     return mAssignmentFormatter;
   }
 
-  public void setAssignmentFormatter(String assignmentFormatter) {
+  public void setAssignmentFormatter(CodeFormatter assignmentFormatter) {
     mAssignmentFormatter = assignmentFormatter;
   }
 
-  public String getSerializeCodeFormatter() {
+  public CodeFormatter getSerializeCodeFormatter() {
     return mSerializeCodeFormatter;
   }
 
-  public void setSerializeCodeFormatter(String serializeCodeFormatter) {
+  public void setSerializeCodeFormatter(CodeFormatter serializeCodeFormatter) {
     mSerializeCodeFormatter = serializeCodeFormatter;
   }
 


### PR DESCRIPTION
This PR prevents `JsonType.serializeCodeFormatter` from expanding collection- or field-specific tokens supported by `JsonField.serializeCodeFormatter`, and prevents `JsonField.serializeCodeFormatter` from expanding the generic `${subobject}` token.

This is a big semantic change for code formatters. Previously, code formatters did not need to be opinionated about which tokens they would accept. Now, they do. So a simple `String` no longer works: an object is required to keep track of which tokens are valid. Therefore, all code formatter strings have been changed into `CodeFormatter` instances.