### PR TITLE
fix collection of enums not being parsed

### DIFF
--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
@@ -322,21 +322,16 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
                 .addParam("extracted_value", "results")
                 .format());
       } else {
-        String rValue = generateExtractRvalue(data, messager, member);
         CodeFormatter assignmentFormatter =
             data.getAssignmentFormatter()
                 .orIfEmpty(
                     mIsKotlin ? DEFAULT_ASSIGNMENT_FORMATTER_KOTLIN : DEFAULT_ASSIGNMENT_FORMATTER);
-        if (data.getJsonAdapterFromJsonMethod() != null) {
-          // If we have a from json method, we call that method with the value
-          rValue = data.getJsonAdapterFromJsonMethod() + "(" + rValue + ")";
-        }
         writer.emitStatement(
             StrFormat.createStringFormatter(assignmentFormatter)
                 .addParam("object_varname", "instance")
                 .addParam("field_varname", member)
                 .addParam("field_varname_setter", getSetterName(member))
-                .addParam("extracted_value", rValue)
+                .addParam("extracted_value", generateExtractRvalue(data, messager, member))
                 .format());
       }
 
@@ -449,7 +444,12 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
           data.getParsableTypeParserClass() + JsonAnnotationProcessorConstants.HELPER_CLASS_SUFFIX);
     }
 
-    return strFormat.format();
+    String rValue = strFormat.format();
+    if (data.getJsonAdapterFromJsonMethod() != null) {
+      // If we have a from json method, we call that method with the value
+      rValue = data.getJsonAdapterFromJsonMethod() + "(" + rValue + ")";
+    }
+    return rValue;
   }
 
   private String getJavaType(Messager messager, TypeData type) {

--- a/processor/src/test/java/com/instagram/common/json/annotation/processor/InterModuleTest.java
+++ b/processor/src/test/java/com/instagram/common/json/annotation/processor/InterModuleTest.java
@@ -15,9 +15,13 @@ import com.instagram.common.json.annotation.processor.dependent.SubclassWithAbst
 import com.instagram.common.json.annotation.processor.dependent.SubclassWithAbstractParentUUT__JsonHelper;
 import com.instagram.common.json.annotation.processor.dependent.WrapperClassUUT;
 import com.instagram.common.json.annotation.processor.dependent.WrapperClassUUT__JsonHelper;
+import com.instagram.common.json.annotation.processor.dependent.WrapperEnumUUT;
+import com.instagram.common.json.annotation.processor.dependent.WrapperEnumUUT__JsonHelper;
 import com.instagram.common.json.annotation.processor.parent.ParentUUT;
 import java.io.IOException;
-import org.json.JSONException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import org.junit.Test;
 
 /** Try to do stuff across modules. */
@@ -25,7 +29,7 @@ public class InterModuleTest {
 
   /** Subclasses a java object in a different class. */
   @Test
-  public void subclassingTest() throws IOException, JSONException {
+  public void subclassingTest() throws IOException {
     final int intValue = 25;
     final String stringValue = "hello world\r\n\'\"";
     final int subIntValue = 30;
@@ -47,7 +51,7 @@ public class InterModuleTest {
 
   /** Subclasses an abstract java object in a different class. */
   @Test
-  public void abstractSubclassingTest() throws IOException, JSONException {
+  public void abstractSubclassingTest() throws IOException {
     final int intValue = 25;
     final String stringValue = "hello world\r\n\'\"";
     final int subIntValue = 30;
@@ -70,7 +74,7 @@ public class InterModuleTest {
 
   /** Includes a java object in a different class. */
   @Test
-  public void wrapperTest() throws IOException, JSONException {
+  public void wrapperTest() throws IOException {
     final int intValue = 25;
     final String stringValue = "hello world\r\n\'\"";
 
@@ -86,5 +90,41 @@ public class InterModuleTest {
 
     assertEquals(uut.parent.parentInt, parsed.parent.parentInt);
     assertEquals(uut.parent.parentString, parsed.parent.parentString);
+  }
+
+  /** Includes enum collections in a different class. */
+  @Test
+  public void enumListAndMapWrappers() throws IOException {
+    WrapperEnumUUT uut = new WrapperEnumUUT();
+    List<MyEnumHolder> list = new ArrayList<>();
+    MyEnumHolder enumHolder1 = new MyEnumHolder(MyEnum.FOO);
+    MyEnumHolder enumHolder2 = new MyEnumHolder(MyEnum.BAR);
+
+    list.add(enumHolder1);
+    list.add(enumHolder2);
+    uut.mMyEnumList = list;
+    HashMap<String, MyEnumHolder> map = new HashMap<>();
+    map.put("key1", enumHolder1);
+    map.put("key2", enumHolder2);
+    uut.mMyEnumMap = map;
+
+    String serialized = WrapperEnumUUT__JsonHelper.serializeToJson(uut);
+    WrapperEnumUUT parsed = WrapperEnumUUT__JsonHelper.parseFromJson(serialized);
+
+    assertEquals(uut.mMyEnumList.size(), parsed.mMyEnumList.size());
+    assertEquals(
+        uut.mMyEnumList.get(0).getMyEnum().getServerValue(),
+        parsed.mMyEnumList.get(0).getMyEnum().getServerValue());
+    assertEquals(
+        uut.mMyEnumList.get(1).getMyEnum().getServerValue(),
+        parsed.mMyEnumList.get(1).getMyEnum().getServerValue());
+
+    assertEquals(uut.mMyEnumMap.size(), 2);
+    assertEquals(
+        uut.mMyEnumMap.get("key1").getMyEnum().getServerValue(),
+        parsed.mMyEnumMap.get("key1").getMyEnum().getServerValue());
+    assertEquals(
+        uut.mMyEnumMap.get("key2").getMyEnum().getServerValue(),
+        parsed.mMyEnumMap.get("key2").getMyEnum().getServerValue());
   }
 }

--- a/processor/testuut/dependent/src/main/java/com/instagram/common/json/annotation/processor/WrapperEnumUUT.java
+++ b/processor/testuut/dependent/src/main/java/com/instagram/common/json/annotation/processor/WrapperEnumUUT.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.instagram.common.json.annotation.processor.dependent;
+
+import com.instagram.common.json.annotation.JsonField;
+import com.instagram.common.json.annotation.JsonType;
+import com.instagram.common.json.annotation.processor.MyEnumHolder;
+import java.util.HashMap;
+import java.util.List;
+
+/** Wrapper for list of enums */
+@JsonType
+public class WrapperEnumUUT {
+  public static final String ENUM_LIST_KEY = "enum_list";
+  public static final String ENUM_MAP_KEY = "enum_map";
+
+  @JsonField(fieldName = ENUM_LIST_KEY)
+  public List<MyEnumHolder> mMyEnumList;
+
+  @JsonField(fieldName = ENUM_MAP_KEY)
+  public HashMap<String, MyEnumHolder> mMyEnumMap;
+}


### PR DESCRIPTION
Summary:
- Enums in igjsonparser are currently supported via `FromJson` annotation. We were supporting them fine for singular instances, but for collections of enums, we were not wrapping the extracted rValue with the `FromJson` adapter method.
- Fixing that up here by just moving the wrapping logic inside of `generateExtractRvalue` which is used for both Lists and Maps.

Differential Revision: D22285285

