### PR TITLE
Supporting wildcard for kotlin interop

### DIFF
--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -31,4 +31,5 @@ dependencies {
     testCompile project(':processor:testuut:kotlin')
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     testCompile "com.google.testing.compile:compile-testing:0.18"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonAnnotationProcessor.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonAnnotationProcessor.java
@@ -348,6 +348,7 @@ public class JsonAnnotationProcessor extends AbstractProcessor {
               .orIfEmpty(serializeCodeType.forString(typeAnnotation.serializeCodeFormatter())));
 
       data.setIsInterface(typeElement.getKind() == INTERFACE);
+      data.setIsWildcard(type != null && type.getKind() == TypeKind.WILDCARD);
       data.setFormatterImports(typeAnnotation.typeFormatterImports());
     } else if (data.getParseType() == TypeUtils.ParseType.ENUM_OBJECT) {
       // verify that we have value extract and serializer formatters.

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/JsonParserClassData.java
@@ -593,7 +593,12 @@ public class JsonParserClassData extends ProcessorClassData<String, TypeData> {
 
   private String getJavaType(Messager messager, TypeData type) {
     if (type.getParseType() == TypeUtils.ParseType.PARSABLE_OBJECT) {
-      return type.getParsableType();
+      StringBuilder sb = new StringBuilder();
+      sb.append(type.getParsableType());
+      if (type.isWildcard() && mIsKotlin) {
+        sb.append("<?>");
+      }
+      return sb.toString();
     }
 
     if (type.getParseType() == TypeUtils.ParseType.ENUM_OBJECT) {

--- a/processor/src/main/java/com/instagram/common/json/annotation/processor/TypeData.java
+++ b/processor/src/main/java/com/instagram/common/json/annotation/processor/TypeData.java
@@ -71,6 +71,8 @@ class TypeData {
 
   private boolean mIsInterface;
 
+  private boolean mIsWildcard;
+
   /** The parse type of the json adapter. */
   private TypeUtils.ParseType mJsonAdapterParseType;
 
@@ -231,15 +233,19 @@ class TypeData {
     return mIsInterface;
   }
 
-  public void setInterface(boolean isInterface) {
-    mIsInterface = isInterface;
-  }
-
   void setFormatterImports(String[] formatterImports) {
     mFormatterImports = Arrays.asList(formatterImports);
   }
 
   List<String> getFormatterImports() {
     return mFormatterImports == null ? Collections.<String>emptyList() : mFormatterImports;
+  }
+
+  public boolean isWildcard() {
+    return mIsWildcard;
+  }
+
+  public void setIsWildcard(boolean wildcard) {
+    mIsWildcard = wildcard;
   }
 }

--- a/processor/src/test/java/com/instagram/common/json/annotation/processor/InterModuleTest.java
+++ b/processor/src/test/java/com/instagram/common/json/annotation/processor/InterModuleTest.java
@@ -127,4 +127,31 @@ public class InterModuleTest {
         uut.mMyEnumMap.get("key2").getMyEnum().getServerValue(),
         parsed.mMyEnumMap.get("key2").getMyEnum().getServerValue());
   }
+
+  /** Includes a collection of generics */
+  @Test
+  public void collectionOfGenerics_serialize_parse() throws IOException {
+    WrapperAnimal animalWrapper = new WrapperAnimal();
+    List<Animal<?>> animals = new ArrayList<>();
+    Dog d1 = new Dog();
+    d1.setName("Alice");
+    Dog d2 = new Dog();
+    d2.setName("Bob");
+    animals.add(d1);
+    animals.add(d2);
+    animalWrapper.setAnimals(animals);
+
+    WrapperWildcardHelper.Companion.registerJsonTypes();
+    String serialized = WrapperAnimal__JsonHelper.serializeToJson(animalWrapper);
+    WrapperAnimal parsed = WrapperAnimal__JsonHelper.parseFromJson(serialized);
+    assertEquals(parsed.animals.size(), 2);
+
+    Animal a1 = parsed.animals.get(0);
+    assertEquals(a1.getId(), "DogAlice");
+    assertEquals(((DogParams) a1.buildParams(a1.getName())).nameLength(), 5);
+
+    Animal a2 = parsed.animals.get(1);
+    assertEquals(a2.getId(), "DogBob");
+    assertEquals(((DogParams) a2.buildParams(a2.getName())).nameLength(), 3);
+  }
 }

--- a/processor/testuut/kotlin/build.gradle
+++ b/processor/testuut/kotlin/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     compile project(':common')
     compile project(':common')
     compile project(':processor')
+    compile project(':processor:testuut:parent')
     kapt project(':processor')
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/processor/testuut/kotlin/src/main/java/com/instagram/common/json/annotation/processor/WrapperWildcard.kt
+++ b/processor/testuut/kotlin/src/main/java/com/instagram/common/json/annotation/processor/WrapperWildcard.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.instagram.common.json.annotation.processor
+
+import com.instagram.common.json.annotation.JsonField
+import com.instagram.common.json.annotation.JsonType
+import com.instagram.common.json.annotation.processor.parent.DynamicDispatchAdapter
+
+/** Used for testing collection of generics */
+@JsonType
+class WrapperAnimal {
+  @JsonField(fieldName = "animals")
+  lateinit var animals: List<Animal<*>>
+}
+
+@JsonType(
+    valueExtractFormatter =
+    "com.instagram.common.json.annotation.processor.WrapperWildcardHelper.Companion.getDISPATCHER().parseFromJson(\${parser_object})",
+    serializeCodeFormatter =
+    "com.instagram.common.json.annotation.processor.WrapperWildcardHelper.Companion.getDISPATCHER().serializeToJson(\${generator_object}, \${subobject})")
+interface Animal<T> : DynamicDispatchAdapter.TypeNameProvider {
+  var name: String
+
+  fun getId(): String
+
+  fun buildParams(name: String): T
+}
+
+interface DogParams {
+  fun nameLength(): Int
+}
+
+@JsonType
+class Dog : Animal<DogParams> {
+  companion object {
+    const val TYPE_NAME: String = "Dog"
+  }
+
+  @JsonField(fieldName = "name")
+  override var name: String = "dog"
+
+  override fun getId(): String {
+    return Dog::class.simpleName + name
+  }
+
+  override fun buildParams(name: String): DogParams {
+    return object : DogParams {
+      override fun nameLength(): Int {
+        return name.length
+      }
+    }
+  }
+
+  override fun getTypeName(): String {
+    return TYPE_NAME
+  }
+}
+
+

--- a/processor/testuut/kotlin/src/main/java/com/instagram/common/json/annotation/processor/WrapperWildcardHelper.kt
+++ b/processor/testuut/kotlin/src/main/java/com/instagram/common/json/annotation/processor/WrapperWildcardHelper.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.instagram.common.json.annotation.processor
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import com.instagram.common.json.annotation.processor.parent.DynamicDispatchAdapter
+import java.io.IOException
+
+/** Helper for [WrapperAnimal] */
+class WrapperWildcardHelper {
+  companion object {
+    val DISPATCHER = DynamicDispatchAdapter<Animal<*>>()
+    fun registerJsonTypes() {
+      DISPATCHER.register(
+          Dog.TYPE_NAME,
+          object : DynamicDispatchAdapter.TypeAdapter<Animal<*>?> {
+            @Throws(IOException::class)
+            override fun parseFromJson(parser: JsonParser): Animal<*> {
+              return Dog__JsonHelper.parseFromJson(parser)
+            }
+
+            @Throws(IOException::class)
+            override fun serializeToJson(generator: JsonGenerator?, obj: Animal<*>?) {
+              Dog__JsonHelper.serializeToJson(generator, obj as Dog, true)
+            }
+          }
+      )
+    }
+  }
+}

--- a/util/src/main/java/com/instagram/common/json/annotation/util/TypeUtils.java
+++ b/util/src/main/java/com/instagram/common/json/annotation/util/TypeUtils.java
@@ -42,6 +42,7 @@ public class TypeUtils {
     STRING,
     PARSABLE_OBJECT,
     ENUM_OBJECT,
+    WILDCARD,
   }
 
   public enum CollectionType {
@@ -105,6 +106,9 @@ public class TypeUtils {
       return ParseType.DOUBLE;
     } else if (JAVA_LANG_DOUBLE.equals(typeMirror.toString())) {
       return ParseType.DOUBLE_OBJECT;
+    } else if (typeMirror.getKind() == TypeKind.WILDCARD) {
+      // If it's a wildcard, assume that annotations are added to properly parse it.
+      return ParseType.PARSABLE_OBJECT;
     } else if (typeMirror instanceof DeclaredType) {
       DeclaredType type = (DeclaredType) typeMirror;
       Element element = type.asElement();


### PR DESCRIPTION
Summary: - This diff adds proper interop support. We can infer whether the type is a wildcard with `TypeKind.WILDCARD` and add the missing `<?>` in the codegen.

Differential Revision: D22402472

