### PR TITLE
Set explicit branch for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Android CI
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
Despite [this blog post](https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/) saying that this macro is supported, I can't get it to [work on my fork](https://github.com/bigfootjon/ig-json-parser/pull/1).

Let's just specify the actual branch name.

Test plan:
GitHub actions is actually running on the PR